### PR TITLE
Add translations for new UI and quiz strings

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -242,6 +242,10 @@
     <string name="labeled">معنون</string>
     <string name="selected">المحدد</string>
     <string name="unlabeled">غير معنون</string>
+    <string name="navigation">التنقل</string>
+    <string name="bottom_navigation">شريط التنقل السفلي</string>
+    <string name="navigation_drawer">قائمة التنقل الجانبية</string>
+    <string name="dashboard">لوحة التحكم</string>
     <string name="code_font">خط الكود</string>
     <string name="language">اللغة</string>
     <string name="notifications">الإشعارات</string>
@@ -356,6 +360,8 @@
     <string name="summary_preference_android_studio_progress_bar">شريط التقدم هو مؤشر مرئي لتقدم مهمة ما. في هذا الدرس، ستتعلم كيفية استخدام كل من أشرطة التقدم الأفقية والدائرية في أندرويد.</string>
     <string name="summary_preference_android_studio_simple_notifications">اتعلم كيفية استخدام الإشعارات في تطبيق أندرويد بتاعك مع هذا الدرس. اكتشف كيفية إنشاء قناة إشعارات ومنشئ، وكيفية عرض الإشعارات للمستخدمين. استكشف الخيارات المختلفة المتاحة لتخصيص إشعاراتك.</string>
     <string name="summary_preference_android_studio_inbox_notifications">اتعلم كيفية استخدام إشعارات نمط البريد الوارد في تطبيق أندرويد بتاعك مع هذا الدرس. اكتشف كيفية إنشاء قناة إشعارات ومنشئ، وكيفية ضبط نمط إشعاراتك إلى InboxStyle مع سطور نصية متعددة ونص ملخص. استكشف الخيارات المختلفة المتاحة لتخصيص إشعارات نمط البريد الوارد.</string>
+    <string name="summary_preference_android_studio_bottom_navigation">تتيح لك شريط التنقل السفلي التنقل بسرعة بين العروض الرئيسية في التطبيق.</string>
+    <string name="summary_preference_android_studio_navigation_drawer">تنزلق قائمة التنقل من الجانب وتعرض خيارات التنقل الرئيسية للتطبيق.</string>
     <string name="summary_alert_dialog_close">متأكد إنك عايز تخرج؟</string>
     <string name="summary_alert_dialog_message">دي هتبقى الرسالة اللي هتشوفها على الشاشة!</string>
     <string name="summary_alert_dialog_require_restart">عشان التغيير يتنفذ، من فضلك أعد تشغيل التطبيق!</string>
@@ -429,5 +435,11 @@
     <string name="daily_tip_unit_tests">اكتب اختبارات الوحدة باستخدام JUnit و Espresso.</string>
     <string name="daily_tip_mvvm">اتبع بنية MVVM لكود قابل للصيانة.</string>
     <string name="tip_of_the_day">نصيحة اليوم</string>
+    <string name="quiz_title">اختبار</string>
+    <string name="next_question">السؤال التالي</string>
+    <string name="quiz_finished">اكتمل الاختبار! نتيجتك: %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">لا مزيد من الأسئلة، تابع التحديثات القادمة للمزيد.</string>
+    <string name="quiz_reminder_title">تذكير الاختبار اليومي</string>
+    <string name="quiz_reminder_body">عد للاختبار اليومي اليوم!</string>
     <string name="other_apps_title">تطبيقات أخرى من المطور</string>
 </resources>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -241,6 +241,10 @@
     <string name="labeled">С етикети</string>
     <string name="selected">Избрани</string>
     <string name="unlabeled">Без етикети</string>
+    <string name="navigation">Навигация</string>
+    <string name="bottom_navigation">Долна навигация</string>
+    <string name="navigation_drawer">Навигационно чекмедже</string>
+    <string name="dashboard">Табло</string>
     <string name="code_font">Шрифт на кода</string>
     <string name="language">Език</string>
     <string name="notifications">Известия</string>
@@ -346,6 +350,8 @@
     <string name="summary_preference_android_studio_progress_bar">Лентата за напредък е визуален индикатор за напредъка на дадена задача. В този урок ще научите как да използвате както хоризонтални, така и кръгови ленти за напредък в Android.</string>
     <string name="summary_preference_android_studio_simple_notifications">Научете как да използвате известия във вашето Android приложение с този урок. Открийте как да създадете канал и конструктор за известия и как да показвате известия на вашите потребители. Разгледайте различните налични опции за персонализиране на вашите известия.</string>
     <string name="summary_preference_android_studio_inbox_notifications">Научете как да използвате известия в стил "Входящи" във вашето Android приложение с този урок. Открийте как да създадете канал и конструктор за известия и как да зададете стила на вашите известия на InboxStyle с множество редове текст и обобщаващ текст. Разгледайте различните налични опции за персонализиране на вашите известия в стил "Входящи".</string>
+    <string name="summary_preference_android_studio_bottom_navigation">Долната навигационна лента позволява бързо превключване между основните изгледи в приложението.</string>
+    <string name="summary_preference_android_studio_navigation_drawer">Навигационното чекмедже се плъзга отстрани и показва основните навигационни опции на приложението.</string>
     <string name="summary_alert_dialog_close">Сигурни ли сте, че искате да излезете?</string>
     <string name="summary_alert_dialog_message">Това ще бъде съобщението, което ще видите на екрана!</string>
     <string name="summary_alert_dialog_require_restart">За да влезе в сила, моля, рестартирайте приложението!</string>
@@ -429,5 +435,11 @@
     <string name="daily_tip_unit_tests">Пиши тестове с JUnit и Espresso.</string>
     <string name="daily_tip_mvvm">Следвайте MVVM архитектурата за поддържане на код.</string>
     <string name="tip_of_the_day">Съвет на деня</string>
+    <string name="quiz_title">Тест</string>
+    <string name="next_question">Следващ въпрос</string>
+    <string name="quiz_finished">Тестът приключи! Вашият резултат: %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">Няма повече въпроси, очаквайте нови в следващи обновления.</string>
+    <string name="quiz_reminder_title">Ежедневно напомняне за тест</string>
+    <string name="quiz_reminder_body">Върнете се за днешния тест!</string>
     <string name="other_apps_title">Още приложения от разработчика</string>
 </resources>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -241,6 +241,10 @@
     <string name="labeled">লেবেলযুক্ত</string>
     <string name="selected">নির্বাচিত</string>
     <string name="unlabeled">লেবেলবিহীন</string>
+    <string name="navigation">নেভিগেশন</string>
+    <string name="bottom_navigation">নীচের নেভিগেশন</string>
+    <string name="navigation_drawer">নেভিগেশন ড্রয়ার</string>
+    <string name="dashboard">ড্যাশবোর্ড</string>
     <string name="code_font">কোড ফন্ট</string>
     <string name="language">ভাষা</string>
     <string name="notifications">বিজ্ঞপ্তি</string>
@@ -346,6 +350,8 @@
     <string name="summary_preference_android_studio_progress_bar">একটি প্রোগ্রেস বার হল একটি কাজের অগ্রগতির একটি ভিজ্যুয়াল সূচক। এই পাঠে, আপনি অ্যান্ড্রয়েডে অনুভূমিক এবং বৃত্তাকার উভয় প্রোগ্রেস বার কীভাবে ব্যবহার করতে হয় তা শিখবেন।</string>
     <string name="summary_preference_android_studio_simple_notifications">এই পাঠের মাধ্যমে আপনার অ্যান্ড্রয়েড অ্যাপে কীভাবে বিজ্ঞপ্তি ব্যবহার করতে হয় তা শিখুন। কীভাবে একটি বিজ্ঞপ্তি চ্যানেল এবং নির্মাতা তৈরি করতে হয় এবং কীভাবে আপনার ব্যবহারকারীদের বিজ্ঞপ্তি দেখাতে হয় তা আবিষ্কার করুন। আপনার বিজ্ঞপ্তিগুলি কাস্টমাইজ করার জন্য উপলব্ধ বিভিন্ন বিকল্পগুলি অন্বেষণ করুন।</string>
     <string name="summary_preference_android_studio_inbox_notifications">এই পাঠের মাধ্যমে আপনার অ্যান্ড্রয়েড অ্যাপে কীভাবে ইনবক্স স্টাইল বিজ্ঞপ্তি ব্যবহার করতে হয় তা শিখুন। কীভাবে একটি বিজ্ঞপ্তি চ্যানেল এবং নির্মাতা তৈরি করতে হয় এবং কীভাবে একাধিক লাইনের টেক্সট এবং একটি সারাংশ টেক্সট সহ একটি ইনবক্সস্টাইলে আপনার বিজ্ঞপ্তিগুলির স্টাইল সেট করতে হয় তা আবিষ্কার করুন। আপনার ইনবক্স স্টাইল বিজ্ঞপ্তিগুলি কাস্টমাইজ করার জন্য উপলব্ধ বিভিন্ন বিকল্পগুলি অন্বেষণ করুন।</string>
+    <string name="summary_preference_android_studio_bottom_navigation">একটি নীচের নেভিগেশন বার আপনাকে দ্রুত অ্যাপের শীর্ষস্তরের ভিউয়ের মাঝে স্যুইচ করতে দেয়।</string>
+    <string name="summary_preference_android_studio_navigation_drawer">একটি নেভিগেশন ড্রয়ার পাশে থেকে স্লাইড করে এবং অ্যাপের প্রধান নেভিগেশন অপশনগুলো দেখায়।</string>
     <string name="summary_alert_dialog_close">আপনি কি নিশ্চিত যে আপনি প্রস্থান করতে চান?</string>
     <string name="summary_alert_dialog_message">এটি সেই বার্তা যা আপনি পর্দায় দেখতে পাবেন!</string>
     <string name="summary_alert_dialog_require_restart">কার্যকর হওয়ার জন্য দয়া করে অ্যাপটি পুনরায় শুরু করুন!</string>
@@ -429,5 +435,11 @@
     <string name="daily_tip_unit_tests">JUN এবং এসপ্রেসোতে ইউনিট পরীক্ষা করো।</string>
     <string name="daily_tip_mvvm">যোগ্য কোডের জন্য এমভিএম স্থাপত্য অনুসরণ করুন।</string>
     <string name="tip_of_the_day">আজকের উপদেশ</string>
+    <string name="quiz_title">কুইজ</string>
+    <string name="next_question">পরবর্তী প্রশ্ন</string>
+    <string name="quiz_finished">কুইজ শেষ! আপনার স্কোর: %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">আর কোনো প্রশ্ন নেই, পরবর্তী আপডেটে দেখুন।</string>
+    <string name="quiz_reminder_title">দৈনিক কুইজ রিমাইন্ডার</string>
+    <string name="quiz_reminder_body">আজকের কুইজে ফিরে আসুন!</string>
     <string name="other_apps_title">ডেভেলপারকে আরো টুল</string>
 </resources>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -241,6 +241,10 @@
     <string name="labeled">Beschriftet</string>
     <string name="selected">Ausgewählt</string>
     <string name="unlabeled">Unbeschriftet</string>
+    <string name="navigation">Navigation</string>
+    <string name="bottom_navigation">Untere Navigation</string>
+    <string name="navigation_drawer">Navigationsleiste</string>
+    <string name="dashboard">Dashboard</string>
     <string name="code_font">Code-Schriftart</string>
     <string name="language">Sprache</string>
     <string name="notifications">Benachrichtigungen</string>
@@ -346,6 +350,8 @@
     <string name="summary_preference_android_studio_progress_bar">Ein Fortschrittsbalken ist ein visueller Indikator für den Fortschritt einer Aufgabe. In dieser Lektion lernen Sie, wie Sie sowohl horizontale als auch kreisförmige Fortschrittsbalken in Android verwenden.</string>
     <string name="summary_preference_android_studio_simple_notifications">Lernen Sie in dieser Lektion, wie Sie Benachrichtigungen in Ihrer Android-App verwenden. Entdecken Sie, wie Sie einen Benachrichtigungskanal und -builder erstellen und wie Sie Ihren Benutzern Benachrichtigungen anzeigen. Erkunden Sie die verschiedenen verfügbaren Optionen zur Anpassung Ihrer Benachrichtigungen.</string>
     <string name="summary_preference_android_studio_inbox_notifications">Lernen Sie in dieser Lektion, wie Sie Benachrichtigungen im Posteingangsstil in Ihrer Android-App verwenden. Entdecken Sie, wie Sie einen Benachrichtigungskanal und -builder erstellen und wie Sie den Stil Ihrer Benachrichtigungen auf einen InboxStyle mit mehreren Textzeilen und einem Zusammenfassungstext einstellen. Erkunden Sie die verschiedenen verfügbaren Optionen zur Anpassung Ihrer Benachrichtigungen im Posteingangsstil.</string>
+    <string name="summary_preference_android_studio_bottom_navigation">Mit einer unteren Navigationsleiste kannst du schnell zwischen Hauptansichten deiner App wechseln.</string>
+    <string name="summary_preference_android_studio_navigation_drawer">Eine Navigationsleiste gleitet von der Seite hinein und zeigt die wichtigsten Navigationsoptionen der App an.</string>
     <string name="summary_alert_dialog_close">Sind Sie sicher, dass Sie beenden möchten?</string>
     <string name="summary_alert_dialog_message">Dies ist die Nachricht, die Sie auf dem Bildschirm sehen werden!</string>
     <string name="summary_alert_dialog_require_restart">Damit die Änderungen wirksam werden, starten Sie bitte die App neu!</string>
@@ -429,5 +435,11 @@
     <string name="daily_tip_unit_tests">Schreibeinheitstests mit JUnit und Espresso.</string>
     <string name="daily_tip_mvvm">Folgen Sie der MVVM-Architektur für den Aufrechterhaltungscode.</string>
     <string name="tip_of_the_day">Tipp des Tages</string>
+    <string name="quiz_title">Quiz</string>
+    <string name="next_question">Nächste Frage</string>
+    <string name="quiz_finished">Quiz abgeschlossen! Deine Punktzahl: %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">Keine weiteren Fragen, schau bei zukünftigen Updates vorbei.</string>
+    <string name="quiz_reminder_title">Tägliche Quiz-Erinnerung</string>
+    <string name="quiz_reminder_body">Komm zurück für das heutige Quiz!</string>
     <string name="other_apps_title">Weitere Apps des Entwicklers</string>
 </resources>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -241,6 +241,10 @@
     <string name="labeled">Etiquetado</string>
     <string name="selected">Seleccionado</string>
     <string name="unlabeled">Sin etiquetar</string>
+    <string name="navigation">Navegación</string>
+    <string name="bottom_navigation">Navegación inferior</string>
+    <string name="navigation_drawer">Panel de navegación</string>
+    <string name="dashboard">Panel de control</string>
     <string name="code_font">Fuente del código</string>
     <string name="language">Idioma</string>
     <string name="notifications">Notificaciones</string>
@@ -346,6 +350,8 @@
     <string name="summary_preference_android_studio_progress_bar">Una barra de progreso es un indicador visual del progreso de una tarea. En esta lección, aprenderás a usar barras de progreso horizontales y circulares en Android.</string>
     <string name="summary_preference_android_studio_simple_notifications">Aprende a usar notificaciones en tu aplicación Android con esta lección. Descubre cómo crear un canal y un constructor de notificaciones, y cómo mostrar notificaciones a tus usuarios. Explora las diferentes opciones disponibles para personalizar tus notificaciones.</string>
     <string name="summary_preference_android_studio_inbox_notifications">Aprende a usar notificaciones de estilo bandeja de entrada en tu aplicación Android con esta lección. Descubre cómo crear un canal y un constructor de notificaciones, y cómo establecer el estilo de tus notificaciones en un InboxStyle con múltiples líneas de texto y un texto de resumen. Explora las diferentes opciones disponibles para personalizar tus notificaciones de estilo bandeja de entrada.</string>
+    <string name="summary_preference_android_studio_bottom_navigation">Una barra de navegación inferior te permite cambiar rápidamente entre las vistas principales de tu app.</string>
+    <string name="summary_preference_android_studio_navigation_drawer">Un panel de navegación se desliza desde el costado y muestra las opciones principales de navegación de la app.</string>
     <string name="summary_alert_dialog_close">¿Estás seguro de que quieres salir?</string>
     <string name="summary_alert_dialog_message">¡Este será el mensaje que verás en pantalla!</string>
     <string name="summary_alert_dialog_require_restart">¡Para que tenga efecto, por favor reinicia la aplicación!</string>
@@ -429,5 +435,11 @@
     <string name="daily_tip_unit_tests">Escribe pruebas de unidad con JUnit y Espresso.</string>
     <string name="daily_tip_mvvm">Siga la arquitectura MVVM para mantener código.</string>
     <string name="tip_of_the_day">Consejo del día</string>
+    <string name="quiz_title">Cuestionario</string>
+    <string name="next_question">Siguiente pregunta</string>
+    <string name="quiz_finished">¡Cuestionario completado! Tu puntuación: %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">No hay más preguntas, revisa futuras actualizaciones para más.</string>
+    <string name="quiz_reminder_title">Recordatorio diario del cuestionario</string>
+    <string name="quiz_reminder_body">¡Vuelve para el cuestionario de hoy!</string>
     <string name="other_apps_title">Más aplicaciones por el desarrollador</string>
 </resources>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -242,6 +242,10 @@
     <string name="labeled">Etiquetado</string>
     <string name="selected">Seleccionado</string>
     <string name="unlabeled">Sin etiquetar</string>
+    <string name="navigation">Navegación</string>
+    <string name="bottom_navigation">Navegación inferior</string>
+    <string name="navigation_drawer">Panel de navegación</string>
+    <string name="dashboard">Panel de control</string>
     <string name="code_font">Fuente del código</string>
     <string name="language">Idioma</string>
     <string name="notifications">Notificaciones</string>
@@ -356,6 +360,8 @@
     <string name="summary_preference_android_studio_progress_bar">Una barra de progreso es un indicador visual del progreso de una tarea. En esta lección, aprenderás a usar tanto las barras de progreso horizontales como las circulares en Android.</string>
     <string name="summary_preference_android_studio_simple_notifications">Aprende a usar notificaciones en tu app de Android con esta lección. Descubre cómo crear un canal y un constructor de notificaciones, y cómo mostrar notificaciones a tus usuarios. Explora las diferentes opciones disponibles para personalizar tus notificaciones.</string>
     <string name="summary_preference_android_studio_inbox_notifications">Aprende a usar notificaciones de estilo bandeja de entrada en tu app de Android con esta lección. Descubre cómo crear un canal y un constructor de notificaciones, y cómo establecer el estilo de tus notificaciones a un InboxStyle con múltiples líneas de texto y un texto de resumen. Explora las diferentes opciones disponibles para personalizar tus notificaciones de estilo bandeja de entrada.</string>
+    <string name="summary_preference_android_studio_bottom_navigation">Una barra de navegación inferior te permite cambiar rápidamente entre las vistas principales de tu app.</string>
+    <string name="summary_preference_android_studio_navigation_drawer">Un panel de navegación se desliza desde el costado y muestra las opciones principales de navegación de la app.</string>
     <string name="summary_alert_dialog_close">¿Estás seguro de que quieres salir?</string>
     <string name="summary_alert_dialog_message">¡Este será el mensaje que verás en la pantalla!</string>
     <string name="summary_alert_dialog_require_restart">¡Para que surta efecto, por favor reinicia la app!</string>
@@ -429,5 +435,11 @@
     <string name="daily_tip_unit_tests">Escribe pruebas unitarias con JUnit y Espresso.</string>
     <string name="daily_tip_mvvm">Sigue la arquitectura MVVM para un código mantenible.</string>
     <string name="tip_of_the_day">Consejo del día</string>
+    <string name="quiz_title">Cuestionario</string>
+    <string name="next_question">Siguiente pregunta</string>
+    <string name="quiz_finished">¡Cuestionario completado! Tu puntuación: %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">No hay más preguntas, revisa futuras actualizaciones para más.</string>
+    <string name="quiz_reminder_title">Recordatorio diario del cuestionario</string>
+    <string name="quiz_reminder_body">¡Vuelve para el cuestionario de hoy!</string>
     <string name="other_apps_title">Más apps del desarrollador</string>
 </resources>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -242,6 +242,10 @@
     <string name="labeled">May label</string>
     <string name="selected">Napili</string>
     <string name="unlabeled">Walang label</string>
+    <string name="navigation">Nabigasyon</string>
+    <string name="bottom_navigation">Nabigasyong nasa ibaba</string>
+    <string name="navigation_drawer">Navigation Drawer</string>
+    <string name="dashboard">Dashboard</string>
     <string name="code_font">Font ng code</string>
     <string name="language">Wika</string>
     <string name="notifications">Mga Notipikasyon</string>
@@ -356,6 +360,8 @@
     <string name="summary_preference_android_studio_progress_bar">Ang isang progress bar ay isang visual na indicator ng progreso ng isang gawain. Sa araling ito, matututunan mo kung paano gamitin ang parehong horizontal at circular na progress bar sa Android.</string>
     <string name="summary_preference_android_studio_simple_notifications">Alamin kung paano gamitin ang mga notipikasyon sa iyong Android app sa araling ito. Tuklasin kung paano gumawa ng isang notification channel at builder, at kung paano magpakita ng mga notipikasyon sa iyong mga user. Galugarin ang iba\'t ibang opsyon na available para i-customize ang iyong mga notipikasyon.</string>
     <string name="summary_preference_android_studio_inbox_notifications">Alamin kung paano gamitin ang mga notipikasyon na may istilong inbox sa iyong Android app sa araling ito. Tuklasin kung paano gumawa ng isang notification channel at builder, at kung paano itakda ang istilo ng iyong mga notipikasyon sa isang InboxStyle na may maraming linya ng text at isang buod na text. Galugarin ang iba\'t ibang opsyon na available para i-customize ang iyong mga notipikasyon na may istilong inbox.</string>
+    <string name="summary_preference_android_studio_bottom_navigation">Ang isang bottom navigation bar ay nagbibigay-daan sa iyong mabilis na lumipat sa mga pangunahing view ng iyong app.</string>
+    <string name="summary_preference_android_studio_navigation_drawer">Ang navigation drawer ay dumudulas mula sa gilid at nagpapakita ng mga pangunahing opsyon sa nabigasyon ng app.</string>
     <string name="summary_alert_dialog_close">Sigurado ka bang gusto mong lumabas?</string>
     <string name="summary_alert_dialog_message">Ito ang magiging mensahe na makikita mo sa screen!</string>
     <string name="summary_alert_dialog_require_restart">Para magkabisa mangyaring i-restart ang app!</string>
@@ -429,5 +435,11 @@
     <string name="daily_tip_unit_tests">Sumulat ng mga unit test gamit ang JUnit at Espresso.</string>
     <string name="daily_tip_mvvm">Sundin ang arkitektura ng MVVM para sa code na madaling i-maintain.</string>
     <string name="tip_of_the_day">Tip ng Araw</string>
+    <string name="quiz_title">Pagsusulit</string>
+    <string name="next_question">Susunod na Tanong</string>
+    <string name="quiz_finished">Tapos na ang pagsusulit! Ang iyong puntos: %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">Wala nang mga tanong, abangan ang susunod na mga update.</string>
+    <string name="quiz_reminder_title">Paalala sa Araw-araw na Pagsusulit</string>
+    <string name="quiz_reminder_body">Bumalik para sa pagsusulit ngayong araw!</string>
     <string name="other_apps_title">Higit pang mga app mula sa developer</string>
 </resources>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -241,6 +241,10 @@
     <string name="labeled">Étiqueté</string>
     <string name="selected">Sélectionné</string>
     <string name="unlabeled">Non étiqueté</string>
+    <string name="navigation">Navigation</string>
+    <string name="bottom_navigation">Navigation inférieure</string>
+    <string name="navigation_drawer">Tiroir de navigation</string>
+    <string name="dashboard">Tableau de bord</string>
     <string name="code_font">Police du code</string>
     <string name="language">Langue</string>
     <string name="notifications">Notifications</string>
@@ -346,6 +350,8 @@
     <string name="summary_preference_android_studio_progress_bar">Une barre de progression est un indicateur visuel de l\'avancement d\'une tâche. Dans cette leçon, vous apprendrez à utiliser les barres de progression horizontales et circulaires dans Android.</string>
     <string name="summary_preference_android_studio_simple_notifications">Apprenez à utiliser les notifications dans votre application Android avec cette leçon. Découvrez comment créer un canal de notification et un constructeur, et comment afficher des notifications à vos utilisateurs. Explorez les différentes options disponibles pour personnaliser vos notifications.</string>
     <string name="summary_preference_android_studio_inbox_notifications">Apprenez à utiliser les notifications de style boîte de réception dans votre application Android avec cette leçon. Découvrez comment créer un canal de notification et un constructeur, et comment définir le style de vos notifications sur un InboxStyle avec plusieurs lignes de texte et un texte récapitulatif. Explorez les différentes options disponibles pour personnaliser vos notifications de style boîte de réception.</string>
+    <string name="summary_preference_android_studio_bottom_navigation">Une barre de navigation inférieure vous permet de passer rapidement entre les vues principales de votre application.</string>
+    <string name="summary_preference_android_studio_navigation_drawer">Un tiroir de navigation se glisse sur le côté et affiche les principales options de navigation de l'application.</string>
     <string name="summary_alert_dialog_close">Êtes-vous sûr de vouloir quitter ?</string>
     <string name="summary_alert_dialog_message">Ce sera le message que vous verrez à l\'écran !</string>
     <string name="summary_alert_dialog_require_restart">Pour que cela prenne effet, veuillez redémarrer l\'application !</string>
@@ -429,5 +435,11 @@
     <string name="daily_tip_unit_tests">Écrire des tests unitaires avec Junit et Espresso.</string>
     <string name="daily_tip_mvvm">Suivez l\'architecture MVVM pour maintenir le code.</string>
     <string name="tip_of_the_day">Astuce du jour</string>
+    <string name="quiz_title">Quiz</string>
+    <string name="next_question">Question suivante</string>
+    <string name="quiz_finished">Quiz terminé ! Votre score : %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">Plus de questions, consultez les prochaines mises à jour pour plus.</string>
+    <string name="quiz_reminder_title">Rappel quotidien du quiz</string>
+    <string name="quiz_reminder_body">Revenez pour le quiz du jour !</string>
     <string name="other_apps_title">Plus d\'applications par le développeur</string>
 </resources>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -221,6 +221,10 @@
     <string name="labeled">लेबल किया हुआ</string>
     <string name="selected">चयनित</string>
     <string name="unlabeled">लेबल रहित</string>
+    <string name="navigation">नेविगेशन</string>
+    <string name="bottom_navigation">निचला नेविगेशन</string>
+    <string name="navigation_drawer">नेविगेशन ड्रॉअर</string>
+    <string name="dashboard">डैशबोर्ड</string>
     <string name="code_font">कोड फ़ॉन्ट</string>
     <string name="language">भाषा</string>
     <string name="notifications">सूचनाएं</string>
@@ -328,6 +332,8 @@
     <string name="summary_preference_android_studio_progress_bar">एक प्रोग्रेस बार एक कार्य की प्रगति का एक दृश्य संकेतक है। इस पाठ में, आप Android में क्षैतिज और वृत्ताकार दोनों प्रोग्रेस बार का उपयोग करना सीखेंगे। </string>
     <string name="summary_preference_android_studio_simple_notifications">इस पाठ के साथ अपने Android ऐप में सूचनाओं का उपयोग करना सीखें। जानें कि एक सूचना चैनल और बिल्डर कैसे बनाएं, और अपने उपयोगकर्ताओं को सूचनाएं कैसे दिखाएं। अपनी सूचनाओं को अनुकूलित करने के लिए उपलब्ध विभिन्न विकल्पों का अन्वेषण करें।</string>
     <string name="summary_preference_android_studio_inbox_notifications">इस पाठ के साथ अपने Android ऐप में इनबॉक्स शैली की सूचनाओं का उपयोग करना सीखें। जानें कि एक सूचना चैनल और बिल्डर कैसे बनाएं, और अपनी सूचनाओं की शैली को कई पंक्तियों के पाठ और एक सारांश पाठ के साथ एक InboxStyle पर कैसे सेट करें। अपनी इनबॉक्स शैली की सूचनाओं को अनुकूलित करने के लिए उपलब्ध विभिन्न विकल्पों का अन्वेषण करें।</string>
+    <string name="summary_preference_android_studio_bottom_navigation">निचली नेविगेशन बार आपको ऐप में शीर्ष स्तर के दृश्य के बीच जल्दी से स्विच करने देती है।</string>
+    <string name="summary_preference_android_studio_navigation_drawer">नेविगेशन ड्रॉअर साइड से स्लाइड करता है और ऐप के मुख्य नेविगेशन विकल्प दिखाता है।</string>
     <string name="summary_alert_dialog_close">क्या आप निश्चित रूप से बाहर निकलना चाहते हैं?</string>
     <string name="summary_alert_dialog_message">यह वह संदेश होगा जो आपको स्क्रीन पर दिखाई देगा!</string>
     <string name="summary_alert_dialog_require_restart">प्रभावित होने के लिए कृपया ऐप को पुनः प्रारंभ करें!</string>
@@ -404,5 +410,11 @@
     <string name="daily_tip_unit_tests">JUnit and Espresso के साथ यूनिट परीक्षण लिखें।</string>
     <string name="daily_tip_mvvm">रखरखाव योग्य कोड के लिए MVVM वास्तुकला का पालन करें।</string>
     <string name="tip_of_the_day">दिन का सुझाव</string>
+    <string name="quiz_title">प्रश्नोत्तरी</string>
+    <string name="next_question">अगला प्रश्न</string>
+    <string name="quiz_finished">प्रश्नोत्तरी पूरी हुई! आपका स्कोर: %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">कोई और प्रश्न नहीं, अधिक के लिए आगामी अपडेट देखें।</string>
+    <string name="quiz_reminder_title">दैनिक प्रश्नोत्तरी अनुस्मारक</string>
+    <string name="quiz_reminder_body">आज की प्रश्नोत्तरी के लिए वापस आएं!</string>
     <string name="other_apps_title">डेवलपर द्वारा अधिक एप्लिकेशन</string>
 </resources>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -221,6 +221,10 @@
     <string name="labeled">Berlabel</string>
     <string name="selected">Terpilih</string>
     <string name="unlabeled">Tidak berlabel</string>
+    <string name="navigation">Navigasi</string>
+    <string name="bottom_navigation">Navigasi Bawah</string>
+    <string name="navigation_drawer">Laci Navigasi</string>
+    <string name="dashboard">Dasbor</string>
     <string name="code_font">Font kode</string>
     <string name="language">Bahasa</string>
     <string name="notifications">Notifikasi</string>
@@ -328,6 +332,8 @@
     <string name="summary_preference_android_studio_progress_bar">Progress bar adalah indikator visual dari kemajuan suatu tugas. Dalam pelajaran ini, Anda akan belajar cara menggunakan progress bar horizontal dan melingkar di Android. </string>
     <string name="summary_preference_android_studio_simple_notifications">Pelajari cara menggunakan notifikasi di aplikasi Android Anda dengan pelajaran ini. Temukan cara membuat saluran notifikasi dan builder, serta cara menampilkan notifikasi kepada pengguna Anda. Jelajahi berbagai opsi yang tersedia untuk menyesuaikan notifikasi Anda.</string>
     <string name="summary_preference_android_studio_inbox_notifications">Pelajari cara menggunakan notifikasi gaya kotak masuk di aplikasi Android Anda dengan pelajaran ini. Temukan cara membuat saluran notifikasi dan builder, dan cara mengatur gaya notifikasi Anda ke InboxStyle dengan beberapa baris teks dan teks ringkasan. Jelajahi berbagai opsi yang tersedia untuk menyesuaikan notifikasi gaya kotak masuk Anda.</string>
+    <string name="summary_preference_android_studio_bottom_navigation">Bilah navigasi bawah memungkinkan Anda dengan cepat beralih antar tampilan tingkat atas di aplikasi Anda.</string>
+    <string name="summary_preference_android_studio_navigation_drawer">Laci navigasi meluncur dari samping dan menampilkan opsi navigasi utama aplikasi.</string>
     <string name="summary_alert_dialog_close">Apakah Anda yakin ingin keluar?</string>
     <string name="summary_alert_dialog_message">Ini akan menjadi pesan yang akan Anda lihat di layar!</string>
     <string name="summary_alert_dialog_require_restart">Agar efektif, harap mulai ulang aplikasi!</string>
@@ -404,5 +410,11 @@
     <string name="daily_tip_unit_tests">Tes unit tulis dengan JUnit dan Espresso.</string>
     <string name="daily_tip_mvvm">Ikuti arsitektur MVVM untuk kode yang dapat dipertahankan.</string>
     <string name="tip_of_the_day">Tip Hari</string>
+    <string name="quiz_title">Kuis</string>
+    <string name="next_question">Pertanyaan Selanjutnya</string>
+    <string name="quiz_finished">Kuis selesai! Skor Anda: %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">Tidak ada lagi pertanyaan, cek pembaruan selanjutnya untuk lebih.</string>
+    <string name="quiz_reminder_title">Pengingat Kuis Harian</string>
+    <string name="quiz_reminder_body">Kembali untuk kuis hari ini!</string>
     <string name="other_apps_title">Lebih banyak aplikasi oleh pengembang</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -242,6 +242,10 @@
     <string name="labeled">라벨 표시</string>
     <string name="selected">선택됨</string>
     <string name="unlabeled">라벨 없음</string>
+    <string name="navigation">내비게이션</string>
+    <string name="bottom_navigation">하단 내비게이션</string>
+    <string name="navigation_drawer">내비게이션 드로어</string>
+    <string name="dashboard">대시보드</string>
     <string name="code_font">코드 글꼴</string>
     <string name="language">언어</string>
     <string name="notifications">알림</string>
@@ -356,6 +360,8 @@
     <string name="summary_preference_android_studio_progress_bar">진행률 표시줄은 작업의 진행 상황을 시각적으로 나타내는 지표입니다. 이 강의에서는 Android에서 수평 및 원형 진행률 표시줄을 사용하는 방법을 배웁니다.</string>
     <string name="summary_preference_android_studio_simple_notifications">이 강의를 통해 Android 앱에서 알림을 사용하는 방법을 배워보세요. 알림 채널과 빌더를 만드는 방법과 사용자에게 알림을 표시하는 방법을 알아보세요. 알림을 사용자 정의하는 데 사용할 수 있는 다양한 옵션을 탐색하세요.</string>
     <string name="summary_preference_android_studio_inbox_notifications">이 강의를 통해 Android 앱에서 받은편지함 스타일 알림을 사용하는 방법을 배워보세요. 알림 채널과 빌더를 만드는 방법과 여러 줄의 텍스트와 요약 텍스트가 있는 InboxStyle로 알림 스타일을 설정하는 방법을 알아보세요. 받은편지함 스타일 알림을 사용자 정의하는 데 사용할 수 있는 다양한 옵션을 탐색하세요.</string>
+    <string name="summary_preference_android_studio_bottom_navigation">하단 내비게이션 바를 사용하면 앱의 최상위 화면을 빠르게 전환할 수 있습니다.</string>
+    <string name="summary_preference_android_studio_navigation_drawer">내비게이션 드로어는 옆에서 슬라이드되며 앱의 주요 탐색 옵션을 표시합니다.</string>
     <string name="summary_alert_dialog_close">종료하시겠습니까?</string>
     <string name="summary_alert_dialog_message">이것이 화면에 표시될 메시지입니다!</string>
     <string name="summary_alert_dialog_require_restart">적용하려면 앱을 다시 시작해주세요!</string>
@@ -429,5 +435,11 @@
     <string name="daily_tip_unit_tests">JUnit과 Espresso로 단위 테스트를 작성하세요.</string>
     <string name="daily_tip_mvvm">유지보수가 용이한 코드를 위해 MVVM 아키텍처를 따르세요.</string>
     <string name="tip_of_the_day">오늘의 팁</string>
+    <string name="quiz_title">퀴즈</string>
+    <string name="next_question">다음 질문</string>
+    <string name="quiz_finished">퀴즈 완료! 점수: %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">더 이상 질문이 없습니다. 추후 업데이트를 확인하세요.</string>
+    <string name="quiz_reminder_title">일일 퀴즈 알림</string>
+    <string name="quiz_reminder_body">오늘의 퀴즈를 위해 다시 오세요!</string>
     <string name="other_apps_title">개발자의 다른 앱</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -242,6 +242,10 @@
     <string name="labeled">Rotulado</string>
     <string name="selected">Selecionado</string>
     <string name="unlabeled">Sem rótulo</string>
+    <string name="navigation">Navegação</string>
+    <string name="bottom_navigation">Navegação inferior</string>
+    <string name="navigation_drawer">Menu lateral</string>
+    <string name="dashboard">Painel</string>
     <string name="code_font">Fonte do código</string>
     <string name="language">Idioma</string>
     <string name="notifications">Notificações</string>
@@ -356,6 +360,8 @@
     <string name="summary_preference_android_studio_progress_bar">Uma barra de progresso é um indicador visual do progresso de uma tarefa. Nesta lição, você aprenderá a usar as barras de progresso horizontais e circulares no Android.</string>
     <string name="summary_preference_android_studio_simple_notifications">Aprenda a usar notificações em seu aplicativo Android com esta lição. Descubra como criar um canal e um construtor de notificações e como mostrar notificações aos seus usuários. Explore as diferentes opções disponíveis para personalizar suas notificações.</string>
     <string name="summary_preference_android_studio_inbox_notifications">Aprenda a usar notificações no estilo de caixa de entrada em seu aplicativo Android com esta lição. Descubra como criar um canal e um construtor de notificações e como definir o estilo de suas notificações para um InboxStyle com várias linhas de texto e um texto de resumo. Explore as diferentes opções disponíveis para personalizar suas notificações no estilo de caixa de entrada.</string>
+    <string name="summary_preference_android_studio_bottom_navigation">Uma barra de navegação inferior permite alternar rapidamente entre as visualizações principais do seu app.</string>
+    <string name="summary_preference_android_studio_navigation_drawer">Um menu lateral desliza pela lateral e exibe as principais opções de navegação do app.</string>
     <string name="summary_alert_dialog_close">Tem certeza de que deseja sair?</string>
     <string name="summary_alert_dialog_message">Esta será a mensagem que você verá na tela!</string>
     <string name="summary_alert_dialog_require_restart">Para ter efeito, por favor, reinicie o aplicativo!</string>
@@ -429,5 +435,11 @@
     <string name="daily_tip_unit_tests">Escreva testes unitários com JUnit e Espresso.</string>
     <string name="daily_tip_mvvm">Siga a arquitetura MVVM para um código de fácil manutenção.</string>
     <string name="tip_of_the_day">Dica do Dia</string>
+    <string name="quiz_title">Quiz</string>
+    <string name="next_question">Próxima pergunta</string>
+    <string name="quiz_finished">Quiz completo! Sua pontuação: %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">Sem mais perguntas, confira as próximas atualizações para mais.</string>
+    <string name="quiz_reminder_title">Lembrete diário do quiz</string>
+    <string name="quiz_reminder_body">Volte para o quiz de hoje!</string>
     <string name="other_apps_title">Mais aplicativos do desenvolvedor</string>
 </resources>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -221,6 +221,10 @@
     <string name="labeled">Etichetate</string>
     <string name="selected">Selectat</string>
     <string name="unlabeled">Neetichetate</string>
+    <string name="navigation">Navigare</string>
+    <string name="bottom_navigation">Navigare de jos</string>
+    <string name="navigation_drawer">Meniu lateral</string>
+    <string name="dashboard">Tablou de bord</string>
     <string name="code_font">Font cod</string>
     <string name="language">Limbă</string>
     <string name="notifications">Notificări</string>
@@ -328,6 +332,8 @@
     <string name="summary_preference_android_studio_progress_bar">O bară de progres este un indicator vizual al progresului unei sarcini. În această lecție, veți învăța cum să utilizați atât barele de progres orizontale, cât și cele circulare în Android.</string>
     <string name="summary_preference_android_studio_simple_notifications">Aflați cum să utilizați notificările în aplicația dvs. Android cu această lecție. Descoperiți cum să creați un canal de notificare și un builder și cum să afișați notificări utilizatorilor dvs. Explorați diferitele opțiuni disponibile pentru personalizarea notificărilor dvs.</string>
     <string name="summary_preference_android_studio_inbox_notifications">Aflați cum să utilizați notificările în stil cutie poștală în aplicația dvs. Android cu această lecție. Descoperiți cum să creați un canal de notificare și un builder și cum să setați stilul notificărilor dvs. la un InboxStyle cu mai multe rânduri de text și un text de rezumat. Explorați diferitele opțiuni disponibile pentru personalizarea notificărilor dvs. în stil cutie poștală.</string>
+    <string name="summary_preference_android_studio_bottom_navigation">O bară de navigare de jos îți permite să comuți rapid între vizualizările de nivel superior ale aplicației.</string>
+    <string name="summary_preference_android_studio_navigation_drawer">Un meniu lateral glisează din partea laterală și afișează principalele opțiuni de navigare ale aplicației.</string>
     <string name="summary_alert_dialog_close">Ești sigur că vrei să ieși?</string>
     <string name="summary_alert_dialog_message">Acesta va fi mesajul pe care îl veți vedea pe ecran!</string>
     <string name="summary_alert_dialog_require_restart">Pentru a produce efect, vă rugăm să reporniți aplicația!</string>
@@ -404,5 +410,11 @@
     <string name="daily_tip_unit_tests">Scrieţi teste de unitate cu JUnit şi Espresso.</string>
     <string name="daily_tip_mvvm">Urmăriți arhitectura MVVM pentru un cod durabil.</string>
     <string name="tip_of_the_day">Sfat al zilei</string>
+    <string name="quiz_title">Chestionar</string>
+    <string name="next_question">Întrebarea următoare</string>
+    <string name="quiz_finished">Chestionar complet! Scorul tău: %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">Nu mai sunt întrebări, urmărește actualizările viitoare pentru mai multe.</string>
+    <string name="quiz_reminder_title">Memento zilnic pentru chestionar</string>
+    <string name="quiz_reminder_body">Revino pentru chestionarul de astăzi!</string>
     <string name="other_apps_title">Mai multe aplicații ale dezvoltatorului</string>
 </resources>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -221,6 +221,10 @@
     <string name="labeled">С подписями</string>
     <string name="selected">Выбрано</string>
     <string name="unlabeled">Без подписей</string>
+    <string name="navigation">Навигация</string>
+    <string name="bottom_navigation">Нижняя навигация</string>
+    <string name="navigation_drawer">Выдвижное меню</string>
+    <string name="dashboard">Панель управления</string>
     <string name="code_font">Шрифт кода</string>
     <string name="language">Язык</string>
     <string name="notifications">Уведомления</string>
@@ -328,6 +332,8 @@
     <string name="summary_preference_android_studio_progress_bar">Индикатор выполнения — это визуальный индикатор прогресса задачи. В этом уроке вы узнаете, как использовать как горизонтальные, так и круговые индикаторы выполнения в Android.</string>
     <string name="summary_preference_android_studio_simple_notifications">В этом уроке вы узнаете, как использовать уведомления в своем приложении Android. Узнайте, как создать канал уведомлений и builder, а также как показывать уведомления своим пользователям. Изучите различные доступные параметры для настройки ваших уведомлений.</string>
     <string name="summary_preference_android_studio_inbox_notifications">В этом уроке вы узнаете, как использовать уведомления в стиле "входящие" в своем приложении Android. Узнайте, как создать канал уведомлений и builder, а также как установить стиль ваших уведомлений на InboxStyle с несколькими строками текста и кратким текстом. Изучите различные доступные параметры для настройки ваших уведомлений в стиле "входящие".</string>
+    <string name="summary_preference_android_studio_bottom_navigation">Панель нижней навигации позволяет быстро переключаться между основными разделами приложения.</string>
+    <string name="summary_preference_android_studio_navigation_drawer">Выдвижное меню появляется сбоку и отображает основные параметры навигации приложения.</string>
     <string name="summary_alert_dialog_close">Вы уверены, что хотите выйти?</string>
     <string name="summary_alert_dialog_message">Это будет сообщение, которое вы увидите на экране!</string>
     <string name="summary_alert_dialog_require_restart">Для вступления в силу, пожалуйста, перезапустите приложение!</string>
@@ -404,5 +410,11 @@
     <string name="daily_tip_unit_tests">Пишите единичные тесты с JUnit и Espresso.</string>
     <string name="daily_tip_mvvm">Следуйте архитектуре MVVM для поддерживающего кода.</string>
     <string name="tip_of_the_day">День Победы</string>
+    <string name="quiz_title">Викторина</string>
+    <string name="next_question">Следующий вопрос</string>
+    <string name="quiz_finished">Викторина завершена! Ваш результат: %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">Вопросы закончились, ждите следующих обновлений.</string>
+    <string name="quiz_reminder_title">Ежедневное напоминание о викторине</string>
+    <string name="quiz_reminder_body">Возвращайтесь на сегодняшнюю викторину!</string>
     <string name="other_apps_title">Больше приложений от разработчика</string>
 </resources>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -242,6 +242,10 @@
     <string name="labeled">Med etikett</string>
     <string name="selected">Vald</string>
     <string name="unlabeled">Utan etikett</string>
+    <string name="navigation">Navigering</string>
+    <string name="bottom_navigation">Nedre navigering</string>
+    <string name="navigation_drawer">Navigeringsmeny</string>
+    <string name="dashboard">Instrumentpanel</string>
     <string name="code_font">Teckensnitt för kod</string>
     <string name="language">Språk</string>
     <string name="notifications">Notiser</string>
@@ -356,6 +360,8 @@
     <string name="summary_preference_android_studio_progress_bar">En förloppsindikator är en visuell indikator på en uppgifts framsteg. I den här lektionen lär du dig hur man använder både horisontella och cirkulära förloppsindikatorer i Android.</string>
     <string name="summary_preference_android_studio_simple_notifications">Lär dig hur du använder notiser i din Android-app med den här lektionen. Upptäck hur du skapar en notiskanal och en byggare, och hur du visar notiser för dina användare. Utforska de olika alternativen som finns tillgängliga för att anpassa dina notiser.</string>
     <string name="summary_preference_android_studio_inbox_notifications">Lär dig hur du använder notiser i inkorgsstil i din Android-app med den här lektionen. Upptäck hur du skapar en notiskanal och en byggare, och hur du ställer in stilen på dina notiser till en InboxStyle med flera textrader och en sammanfattningstext. Utforska de olika alternativen som finns tillgängliga för att anpassa dina notiser i inkorgsstil.</string>
+    <string name="summary_preference_android_studio_bottom_navigation">En nedre navigeringsrad låter dig snabbt växla mellan huvudvyerna i appen.</string>
+    <string name="summary_preference_android_studio_navigation_drawer">En navigeringsmeny glider in från sidan och visar appens viktigaste navigeringsalternativ.</string>
     <string name="summary_alert_dialog_close">Är du säker på att du vill avsluta?</string>
     <string name="summary_alert_dialog_message">Detta kommer att vara meddelandet du ser på skärmen!</string>
     <string name="summary_alert_dialog_require_restart">För att träda i kraft, starta om appen!</string>
@@ -429,5 +435,11 @@
     <string name="daily_tip_unit_tests">Skriv enhetstester med JUnit och Espresso.</string>
     <string name="daily_tip_mvvm">Följ MVVM-arkitekturen för underhållbar kod.</string>
     <string name="tip_of_the_day">Dagens tips</string>
+    <string name="quiz_title">Quiz</string>
+    <string name="next_question">Nästa fråga</string>
+    <string name="quiz_finished">Quiz klart! Ditt resultat: %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">Inga fler frågor, se kommande uppdateringar för mer.</string>
+    <string name="quiz_reminder_title">Daglig quizpåminnelse</string>
+    <string name="quiz_reminder_body">Kom tillbaka för dagens quiz!</string>
     <string name="other_apps_title">Fler appar av utvecklaren</string>
 </resources>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -242,6 +242,10 @@
     <string name="labeled">มีป้ายกำกับ</string>
     <string name="selected">ที่เลือก</string>
     <string name="unlabeled">ไม่มีป้ายกำกับ</string>
+    <string name="navigation">การนำทาง</string>
+    <string name="bottom_navigation">แถบนำทางด้านล่าง</string>
+    <string name="navigation_drawer">ลิ้นชักนำทาง</string>
+    <string name="dashboard">แดชบอร์ด</string>
     <string name="code_font">แบบอักษรของโค้ด</string>
     <string name="language">ภาษา</string>
     <string name="notifications">การแจ้งเตือน</string>
@@ -356,6 +360,8 @@
     <string name="summary_preference_android_studio_progress_bar">แถบความคืบหน้าคือตัวบ่งชี้ภาพของความคืบหน้าของงาน ในบทเรียนนี้, คุณจะได้เรียนรู้วิธีใช้ทั้งแถบความคืบหน้าแนวนอนและวงกลมใน Android</string>
     <string name="summary_preference_android_studio_simple_notifications">เรียนรู้วิธีใช้การแจ้งเตือนในแอป Android ของคุณด้วยบทเรียนนี้ ค้นพบวิธีสร้างช่องทางการแจ้งเตือนและตัวสร้าง, และวิธีแสดงการแจ้งเตือนให้ผู้ใช้ของคุณเห็น สำรวจตัวเลือกต่างๆ ที่มีอยู่เพื่อปรับแต่งการแจ้งเตือนของคุณ</string>
     <string name="summary_preference_android_studio_inbox_notifications">เรียนรู้วิธีใช้การแจ้งเตือนสไตล์กล่องข้อความในแอป Android ของคุณด้วยบทเรียนนี้ ค้นพบวิธีสร้างช่องทางการแจ้งเตือนและตัวสร้าง, และวิธีตั้งค่าสไตล์ของการแจ้งเตือนของคุณเป็น InboxStyle ที่มีข้อความหลายบรรทัดและข้อความสรุป สำรวจตัวเลือกต่างๆ ที่มีอยู่เพื่อปรับแต่งการแจ้งเตือนสไตล์กล่องข้อความของคุณ</string>
+    <string name="summary_preference_android_studio_bottom_navigation">แถบนำทางด้านล่างช่วยให้คุณสลับระหว่างมุมมองหลักของแอปได้อย่างรวดเร็ว</string>
+    <string name="summary_preference_android_studio_navigation_drawer">ลิ้นชักนำทางเลื่อนมาจากด้านข้างและแสดงตัวเลือกการนำทางหลักของแอป</string>
     <string name="summary_alert_dialog_close">คุณแน่ใจหรือไม่ว่าต้องการออก?</string>
     <string name="summary_alert_dialog_message">นี่คือข้อความที่คุณจะเห็นบนหน้าจอ!</string>
     <string name="summary_alert_dialog_require_restart">เพื่อให้มีผล กรุณารีสตาร์ทแอป!</string>
@@ -429,5 +435,11 @@
     <string name="daily_tip_unit_tests">เขียนการทดสอบหน่วยด้วย JUnit และ Espresso</string>
     <string name="daily_tip_mvvm">ปฏิบัติตามสถาปัตยกรรม MVVM เพื่อโค้ดที่บำรุงรักษาง่าย</string>
     <string name="tip_of_the_day">เคล็ดลับประจำวัน</string>
+    <string name="quiz_title">แบบทดสอบ</string>
+    <string name="next_question">คำถามถัดไป</string>
+    <string name="quiz_finished">ทำแบบทดสอบเสร็จสิ้น! คะแนนของคุณ: %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">ไม่มีคำถามเพิ่มเติม โปรดติดตามการอัปเดตต่อไป</string>
+    <string name="quiz_reminder_title">การแจ้งเตือนแบบทดสอบรายวัน</string>
+    <string name="quiz_reminder_body">กลับมาทำแบบทดสอบของวันนี้!</string>
     <string name="other_apps_title">แอปอื่นๆ จากนักพัฒนา</string>
 </resources>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -242,6 +242,10 @@
     <string name="labeled">Etiketli</string>
     <string name="selected">Seçili</string>
     <string name="unlabeled">Etiketsiz</string>
+    <string name="navigation">Gezinme</string>
+    <string name="bottom_navigation">Alt gezinme</string>
+    <string name="navigation_drawer">Gezinme çekmecesi</string>
+    <string name="dashboard">Kontrol paneli</string>
     <string name="code_font">Kod yazı tipi</string>
     <string name="language">Dil</string>
     <string name="notifications">Bildirimler</string>
@@ -356,6 +360,8 @@
     <string name="summary_preference_android_studio_progress_bar">Bir ilerleme çubuğu, bir görevin ilerlemesinin görsel bir göstergesidir. Bu derste, Android\'de hem yatay hem de dairesel ilerleme çubuklarını nasıl kullanacağınızı öğreneceksiniz.</string>
     <string name="summary_preference_android_studio_simple_notifications">Bu dersle Android uygulamanızda bildirimleri nasıl kullanacağınızı öğrenin. Bir bildirim kanalı ve oluşturucu nasıl oluşturulacağını ve kullanıcılarınıza bildirimleri nasıl göstereceğinizi keşfedin. Bildirimlerinizi özelleştirmek için mevcut farklı seçenekleri keşfedin.</string>
     <string name="summary_preference_android_studio_inbox_notifications">Bu dersle Android uygulamanızda gelen kutusu stili bildirimleri nasıl kullanacağınızı öğrenin. Bir bildirim kanalı ve oluşturucu nasıl oluşturulacağını ve bildirimlerinizin stilini birden çok metin satırı ve bir özet metni içeren bir InboxStyle olarak nasıl ayarlayacağınızı keşfedin. Gelen kutusu stili bildirimlerinizi özelleştirmek için mevcut farklı seçenekleri keşfedin.</string>
+    <string name="summary_preference_android_studio_bottom_navigation">Bir alt gezinme çubuğu, uygulamanızdaki üst düzey görünümler arasında hızlıca geçiş yapmanızı sağlar.</string>
+    <string name="summary_preference_android_studio_navigation_drawer">Gezinme çekmecesi kenardan kayarak gelir ve uygulamanın ana gezinme seçeneklerini gösterir.</string>
     <string name="summary_alert_dialog_close">Çıkmak istediğinizden emin misiniz?</string>
     <string name="summary_alert_dialog_message">Bu, ekranda göreceğiniz mesaj olacak!</string>
     <string name="summary_alert_dialog_require_restart">Etkili olması için lütfen uygulamayı yeniden başlatın!</string>
@@ -429,5 +435,11 @@
     <string name="daily_tip_unit_tests">JUnit ve Espresso ile birim testleri yazın.</string>
     <string name="daily_tip_mvvm">Bakımı kolay kod için MVVM mimarisini takip edin.</string>
     <string name="tip_of_the_day">Günün İpucu</string>
+    <string name="quiz_title">Test</string>
+    <string name="next_question">Sonraki Soru</string>
+    <string name="quiz_finished">Test tamamlandı! Skorunuz: %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">Başka soru yok, daha fazlası için güncellemeleri kontrol edin.</string>
+    <string name="quiz_reminder_title">Günlük Test Hatırlatıcısı</string>
+    <string name="quiz_reminder_body">Bugünün testi için geri gelin!</string>
     <string name="other_apps_title">Geliştiricinin diğer uygulamaları</string>
 </resources>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -242,6 +242,10 @@
     <string name="labeled">З підписами</string>
     <string name="selected">Вибрані</string>
     <string name="unlabeled">Без підписів</string>
+    <string name="navigation">Навігація</string>
+    <string name="bottom_navigation">Нижня навігація</string>
+    <string name="navigation_drawer">Бічне меню</string>
+    <string name="dashboard">Панель</string>
     <string name="code_font">Шрифт коду</string>
     <string name="language">Мова</string>
     <string name="notifications">Сповіщення</string>
@@ -356,6 +360,8 @@
     <string name="summary_preference_android_studio_progress_bar">Індикатор прогресу — це візуальний індикатор виконання завдання. У цьому уроці ви навчитеся використовувати як горизонтальні, так і кругові індикатори прогресу в Android.</string>
     <string name="summary_preference_android_studio_simple_notifications">Навчіться використовувати сповіщення у вашому додатку для Android за допомогою цього уроку. Дізнайтеся, як створити канал сповіщень та конструктор, а також як показувати сповіщення вашим користувачам. Дослідіть різні доступні варіанти для налаштування ваших сповіщень.</string>
     <string name="summary_preference_android_studio_inbox_notifications">Навчіться використовувати сповіщення у стилі "вхідні" у вашому додатку для Android за допомогою цього уроку. Дізнайтеся, як створити канал сповіщень та конструктор, а також як встановити стиль ваших сповіщень на InboxStyle з кількома рядками тексту та текстом-резюме. Дослідіть різні доступні варіанти для налаштування ваших сповіщень у стилі "вхідні".</string>
+    <string name="summary_preference_android_studio_bottom_navigation">Панель нижньої навігації дозволяє швидко перемикатися між основними розділами програми.</string>
+    <string name="summary_preference_android_studio_navigation_drawer">Бічне меню виїжджає з боку та показує основні параметри навігації програми.</string>
     <string name="summary_alert_dialog_close">Ви впевнені, що хочете вийти?</string>
     <string name="summary_alert_dialog_message">Це буде повідомлення, яке ви побачите на екрані!</string>
     <string name="summary_alert_dialog_require_restart">Щоб зміни набули чинності, будь ласка, перезапустіть додаток!</string>
@@ -429,5 +435,11 @@
     <string name="daily_tip_unit_tests">Пишіть юніт-тести з JUnit та Espresso.</string>
     <string name="daily_tip_mvvm">Дотримуйтесь архітектури MVVM для коду, який легко підтримувати.</string>
     <string name="tip_of_the_day">Порада дня</string>
+    <string name="quiz_title">Вікторина</string>
+    <string name="next_question">Наступне запитання</string>
+    <string name="quiz_finished">Вікторину завершено! Ваш рахунок: %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">Більше питань немає, стежте за оновленнями.</string>
+    <string name="quiz_reminder_title">Щоденне нагадування про вікторину</string>
+    <string name="quiz_reminder_body">Поверніться на сьогоднішню вікторину!</string>
     <string name="other_apps_title">Інші додатки розробника</string>
 </resources>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -242,6 +242,10 @@
     <string name="labeled">لیبل شدہ</string>
     <string name="selected">منتخب</string>
     <string name="unlabeled">بغیر لیبل کے</string>
+    <string name="navigation">نیوی گیشن</string>
+    <string name="bottom_navigation">نیچے کی نیوی گیشن</string>
+    <string name="navigation_drawer">نیوی گیشن دراز</string>
+    <string name="dashboard">ڈیش بورڈ</string>
     <string name="code_font">کوڈ فونٹ</string>
     <string name="language">زبان</string>
     <string name="notifications">نوٹیفکیشنز</string>
@@ -356,6 +360,8 @@
     <string name="summary_preference_android_studio_progress_bar">پروگریس بار کسی کام کی پیشرفت کا ایک بصری اشارہ ہے۔ اس سبق میں، آپ اینڈرائیڈ میں افقی اور سرکلر دونوں پروگریس بار استعمال کرنا سیکھیں گے۔</string>
     <string name="summary_preference_android_studio_simple_notifications">اس سبق کے ساتھ اپنی اینڈرائیڈ ایپ میں نوٹیفکیشنز کا استعمال سیکھیں۔ نوٹیفکیشن چینل اور بلڈر بنانے کا طریقہ، اور اپنے صارفین کو نوٹیفکیشنز دکھانے کا طریقہ دریافت کریں۔ اپنے نوٹیفکیشنز کو اپنی مرضی کے مطابق بنانے کے لیے دستیاب مختلف اختیارات دریافت کریں۔</string>
     <string name="summary_preference_android_studio_inbox_notifications">اس سبق کے ساتھ اپنی اینڈرائیڈ ایپ میں ان باکس اسٹائل نوٹیفکیشنز کا استعمال سیکھیں۔ نوٹیفکیشن چینل اور بلڈر بنانے کا طریقہ، اور اپنے نوٹیفکیشنز کے اسٹائل کو متعدد لائنوں کے متن اور خلاصہ متن کے ساتھ ان باکس اسٹائل پر سیٹ کرنے کا طریقہ دریافت کریں۔ اپنے ان باکس اسٹائل نوٹیفکیشنز کو اپنی مرضی کے مطابق بنانے کے لیے دستیاب مختلف اختیارات دریافت کریں۔</string>
+    <string name="summary_preference_android_studio_bottom_navigation">نیچے کی نیوی گیشن بار آپ کو ایپ کے اعلیٰ سطحی مناظر کے درمیان تیزی سے سوئچ کرنے دیتی ہے۔</string>
+    <string name="summary_preference_android_studio_navigation_drawer">نیوی گیشن دراز سائیڈ سے سلائیڈ ہوتا ہے اور ایپ کے اہم نیوی گیشن اختیارات دکھاتا ہے۔</string>
     <string name="summary_alert_dialog_close">کیا آپ واقعی باہر نکلنا چاہتے ہیں؟</string>
     <string name="summary_alert_dialog_message">یہ وہ پیغام ہوگا جو آپ اسکرین پر دیکھیں گے!</string>
     <string name="summary_alert_dialog_require_restart">اثر انداز ہونے کے لیے براہ کرم ایپ کو دوبارہ شروع کریں!</string>
@@ -429,5 +435,11 @@
     <string name="daily_tip_unit_tests">JUnit اور Espresso کے ساتھ یونٹ ٹیسٹ لکھیں۔</string>
     <string name="daily_tip_mvvm">قابل دیکھ بھال کوڈ کے لیے MVVM آرکیٹیکچر کی پیروی کریں۔</string>
     <string name="tip_of_the_day">آج کی ٹپ</string>
+    <string name="quiz_title">کوئز</string>
+    <string name="next_question">اگلا سوال</string>
+    <string name="quiz_finished">کوئز مکمل! آپ کا اسکور: %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">مزید سوالات نہیں، مزید کے لیے آنے والی اپ ڈیٹس دیکھیں۔</string>
+    <string name="quiz_reminder_title">روزانہ کوئز یاددہانی</string>
+    <string name="quiz_reminder_body">آج کے کوئز کے لیے دوبارہ آئیں!</string>
     <string name="other_apps_title">ڈیولپر کی مزید ایپس</string>
 </resources>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -242,6 +242,10 @@
     <string name="labeled">Có nhãn</string>
     <string name="selected">Đã chọn</string>
     <string name="unlabeled">Không có nhãn</string>
+    <string name="navigation">Điều hướng</string>
+    <string name="bottom_navigation">Thanh điều hướng dưới</string>
+    <string name="navigation_drawer">Ngăn điều hướng</string>
+    <string name="dashboard">Bảng điều khiển</string>
     <string name="code_font">Phông chữ mã</string>
     <string name="language">Ngôn ngữ</string>
     <string name="notifications">Thông báo</string>
@@ -356,6 +360,8 @@
     <string name="summary_preference_android_studio_progress_bar">Thanh tiến trình là một chỉ báo trực quan về tiến trình của một tác vụ. Trong bài học này, bạn sẽ học cách sử dụng cả thanh tiến trình ngang và tròn trong Android.</string>
     <string name="summary_preference_android_studio_simple_notifications">Tìm hiểu cách sử dụng thông báo trong ứng dụng Android của bạn với bài học này. Khám phá cách tạo kênh thông báo và trình tạo, và cách hiển thị thông báo cho người dùng của bạn. Khám phá các tùy chọn khác nhau có sẵn để tùy chỉnh thông báo của bạn.</string>
     <string name="summary_preference_android_studio_inbox_notifications">Tìm hiểu cách sử dụng thông báo kiểu hộp thư đến trong ứng dụng Android của bạn với bài học này. Khám phá cách tạo kênh thông báo và trình tạo, và cách đặt kiểu thông báo của bạn thành InboxStyle với nhiều dòng văn bản và một văn bản tóm tắt. Khám phá các tùy chọn khác nhau có sẵn để tùy chỉnh thông báo kiểu hộp thư đến của bạn.</string>
+    <string name="summary_preference_android_studio_bottom_navigation">Thanh điều hướng dưới cho phép bạn nhanh chóng chuyển đổi giữa các chế độ xem cấp cao trong ứng dụng.</string>
+    <string name="summary_preference_android_studio_navigation_drawer">Ngăn điều hướng trượt từ bên cạnh vào và hiển thị các tùy chọn điều hướng chính của ứng dụng.</string>
     <string name="summary_alert_dialog_close">Bạn có chắc chắn muốn thoát?</string>
     <string name="summary_alert_dialog_message">Đây sẽ là thông báo bạn sẽ thấy trên màn hình!</string>
     <string name="summary_alert_dialog_require_restart">Để có hiệu lực, vui lòng khởi động lại ứng dụng!</string>
@@ -429,5 +435,11 @@
     <string name="daily_tip_unit_tests">Viết các bài kiểm tra đơn vị với JUnit và Espresso.</string>
     <string name="daily_tip_mvvm">Tuân theo kiến trúc MVVM để có mã có thể bảo trì.</string>
     <string name="tip_of_the_day">Mẹo trong ngày</string>
+    <string name="quiz_title">Câu đố</string>
+    <string name="next_question">Câu hỏi tiếp theo</string>
+    <string name="quiz_finished">Hoàn thành câu đố! Điểm của bạn: %1$d/%2$d</string>
+    <string name="quiz_no_more_questions">Hết câu hỏi, hãy xem các bản cập nhật sau để có thêm.</string>
+    <string name="quiz_reminder_title">Nhắc nhở làm quiz hằng ngày</string>
+    <string name="quiz_reminder_body">Quay lại để làm quiz hôm nay!</string>
     <string name="other_apps_title">Các ứng dụng khác của nhà phát triển</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -242,6 +242,10 @@
     <string name="labeled">有標籤</string>
     <string name="selected">已選取</string>
     <string name="unlabeled">無標籤</string>
+    <string name="navigation">導覽</string>
+    <string name="bottom_navigation">底部導覽列</string>
+    <string name="navigation_drawer">側邊選單</string>
+    <string name="dashboard">儀表板</string>
     <string name="code_font">程式碼字型</string>
     <string name="language">語言</string>
     <string name="notifications">通知</string>
@@ -357,6 +361,8 @@
     <string name="summary_preference_android_studio_progress_bar">進度列是任務進度的視覺指標。在本課程中，您將學習如何在 Android 中使用水平和圓形進度列。</string>
     <string name="summary_preference_android_studio_simple_notifications">透過本課程學習如何在您的 Android 應用程式中使用通知。探索如何建立通知通道和建構器，以及如何向您的使用者顯示通知。探索可用於自訂通知的不同選項。</string>
     <string name="summary_preference_android_studio_inbox_notifications">透過本課程學習如何在您的 Android 應用程式中使用收件匣樣式的通知。探索如何建立通知通道和建構器，以及如何將通知的樣式設定為具有多行文字和摘要文字的 InboxStyle。探索可用於自訂收件匣樣式通知的不同選項。</string>
+    <string name="summary_preference_android_studio_bottom_navigation">底部導覽列可讓你快速在應用程式的頂層檢視之間切換。</string>
+    <string name="summary_preference_android_studio_navigation_drawer">側邊選單從側邊滑入並顯示應用程式的主要導覽選項。</string>
     <string name="summary_alert_dialog_close">您確定要退出嗎？</string>
     <string name="summary_alert_dialog_message">這將是您在螢幕上看到的訊息！</string>
     <string name="summary_alert_dialog_require_restart">為使變更生效，請重新啟動應用程式！</string>
@@ -430,5 +436,11 @@
     <string name="daily_tip_unit_tests">使用 JUnit 和 Espresso 編寫單元測試。</string>
     <string name="daily_tip_mvvm">遵循 MVVM 架構以獲得可維護的程式碼。</string>
     <string name="tip_of_the_day">今日提示</string>
+    <string name="quiz_title">小測驗</string>
+    <string name="next_question">下一題</string>
+    <string name="quiz_finished">測驗完成！你的分數：%1$d/%2$d</string>
+    <string name="quiz_no_more_questions">沒有更多題目，請留意之後的更新。</string>
+    <string name="quiz_reminder_title">每日測驗提醒</string>
+    <string name="quiz_reminder_body">回來參加今天的測驗吧！</string>
     <string name="other_apps_title">開發人員的其他應用程式</string>
 </resources>


### PR DESCRIPTION
## Summary
- translate navigation and quiz-related strings for all supported locales

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68873a451688832da777f3b3a4f08556