### PR TITLE
refactor: use data layer repositories in domain

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/AboutRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/AboutRepository.java
@@ -1,0 +1,6 @@
+package com.d4rk.androidtutorials.java.data.repository;
+
+public interface AboutRepository {
+    String getVersionString();
+    String getCurrentYear();
+}

--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/HelpRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/HelpRepository.java
@@ -1,0 +1,14 @@
+package com.d4rk.androidtutorials.java.data.repository;
+
+import android.app.Activity;
+import com.google.android.play.core.review.ReviewInfo;
+
+public interface HelpRepository {
+    void requestReviewFlow(OnReviewInfoListener listener);
+    void launchReviewFlow(Activity activity, ReviewInfo reviewInfo);
+
+    interface OnReviewInfoListener {
+        void onSuccess(ReviewInfo info);
+        void onFailure(Exception e);
+    }
+}

--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/LessonRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/LessonRepository.java
@@ -1,0 +1,6 @@
+package com.d4rk.androidtutorials.java.data.repository;
+
+public interface LessonRepository {
+    record Lesson(int titleResId, int codeResId, int layoutResId) {}
+    Lesson getLesson(String lessonName);
+}

--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/MainRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/MainRepository.java
@@ -1,0 +1,17 @@
+package com.d4rk.androidtutorials.java.data.repository;
+
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import com.google.android.play.core.appupdate.AppUpdateManager;
+
+public interface MainRepository {
+    boolean isAppInstalled(PackageManager packageManager, String packageName);
+    boolean applyThemeSettings(String[] darkModeValues);
+    String getBottomNavLabelVisibility(String labelKey, String labelDefaultValue);
+    String getDefaultTabPreference(String defaultTabKey, String defaultTabValue);
+    boolean shouldShowStartupScreen();
+    void markStartupScreenShown();
+    void applyLanguageSettings();
+    AppUpdateManager getAppUpdateManager();
+    Intent buildShortcutIntent(boolean isInstalled);
+}

--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/SettingsRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/SettingsRepository.java
@@ -1,0 +1,10 @@
+package com.d4rk.androidtutorials.java.data.repository;
+
+import android.content.SharedPreferences;
+
+public interface SettingsRepository {
+    void handlePreferenceChange(String key);
+    boolean applyTheme();
+    void applyConsent();
+    SharedPreferences getSharedPreferences();
+}

--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/StartupRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/StartupRepository.java
@@ -1,0 +1,19 @@
+package com.d4rk.androidtutorials.java.data.repository;
+
+import android.app.Activity;
+import com.google.android.ump.ConsentRequestParameters;
+import com.google.android.ump.FormError;
+
+public interface StartupRepository {
+    void requestConsentInfoUpdate(
+            Activity activity,
+            ConsentRequestParameters params,
+            Runnable onSuccess,
+            OnFormError onError);
+
+    void loadConsentForm(Activity activity, OnFormError onError);
+
+    interface OnFormError {
+        void onFormError(FormError error);
+    }
+}

--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/SupportRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/SupportRepository.java
@@ -1,0 +1,17 @@
+package com.d4rk.androidtutorials.java.data.repository;
+
+import android.app.Activity;
+import com.android.billingclient.api.ProductDetails;
+import com.d4rk.androidtutorials.java.databinding.ActivitySupportBinding;
+import java.util.List;
+
+public interface SupportRepository {
+    void initBillingClient(Runnable onConnected);
+    void queryProductDetails(List<String> productIds, OnProductDetailsListener listener);
+    void initiatePurchase(Activity activity, String productId);
+    void initMobileAds(ActivitySupportBinding binding);
+
+    interface OnProductDetailsListener {
+        void onProductDetailsRetrieved(List<ProductDetails> productDetailsList);
+    }
+}

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/about/GetCurrentYearUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/about/GetCurrentYearUseCase.java
@@ -1,6 +1,6 @@
 package com.d4rk.androidtutorials.java.domain.about;
 
-import com.d4rk.androidtutorials.java.ui.screens.about.repository.AboutRepository;
+import com.d4rk.androidtutorials.java.data.repository.AboutRepository;
 
 /** Provides current year as a string. */
 public class GetCurrentYearUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/about/GetVersionStringUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/about/GetVersionStringUseCase.java
@@ -1,6 +1,6 @@
 package com.d4rk.androidtutorials.java.domain.about;
 
-import com.d4rk.androidtutorials.java.ui.screens.about.repository.AboutRepository;
+import com.d4rk.androidtutorials.java.data.repository.AboutRepository;
 
 /** Returns the formatted app version string. */
 public class GetVersionStringUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/android/GetLessonUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/android/GetLessonUseCase.java
@@ -1,6 +1,6 @@
 package com.d4rk.androidtutorials.java.domain.android;
 
-import com.d4rk.androidtutorials.java.ui.screens.android.repository.LessonRepository;
+import com.d4rk.androidtutorials.java.data.repository.LessonRepository;
 
 /** Retrieves lesson data by name. */
 public class GetLessonUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/help/LaunchReviewFlowUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/help/LaunchReviewFlowUseCase.java
@@ -1,7 +1,7 @@
 package com.d4rk.androidtutorials.java.domain.help;
 
 import android.app.Activity;
-import com.d4rk.androidtutorials.java.ui.screens.help.repository.HelpRepository;
+import com.d4rk.androidtutorials.java.data.repository.HelpRepository;
 import com.google.android.play.core.review.ReviewInfo;
 
 /** Launches the in-app review flow. */

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/help/RequestReviewFlowUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/help/RequestReviewFlowUseCase.java
@@ -1,6 +1,6 @@
 package com.d4rk.androidtutorials.java.domain.help;
 
-import com.d4rk.androidtutorials.java.ui.screens.help.repository.HelpRepository;
+import com.d4rk.androidtutorials.java.data.repository.HelpRepository;
 
 /** Requests the Google Play review flow. */
 public class RequestReviewFlowUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/ApplyLanguageSettingsUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/ApplyLanguageSettingsUseCase.java
@@ -1,6 +1,6 @@
 package com.d4rk.androidtutorials.java.domain.main;
 
-import com.d4rk.androidtutorials.java.ui.screens.main.repository.MainRepository;
+import com.d4rk.androidtutorials.java.data.repository.MainRepository;
 
 /** Applies the saved language preference. */
 public class ApplyLanguageSettingsUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/ApplyThemeSettingsUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/ApplyThemeSettingsUseCase.java
@@ -1,6 +1,6 @@
 package com.d4rk.androidtutorials.java.domain.main;
 
-import com.d4rk.androidtutorials.java.ui.screens.main.repository.MainRepository;
+import com.d4rk.androidtutorials.java.data.repository.MainRepository;
 
 /** Applies theme preference and returns true if changed. */
 public class ApplyThemeSettingsUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/BuildShortcutIntentUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/BuildShortcutIntentUseCase.java
@@ -1,7 +1,7 @@
 package com.d4rk.androidtutorials.java.domain.main;
 
 import android.content.Intent;
-import com.d4rk.androidtutorials.java.ui.screens.main.repository.MainRepository;
+import com.d4rk.androidtutorials.java.data.repository.MainRepository;
 
 /** Creates an intent for the app shortcut. */
 public class BuildShortcutIntentUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/GetAppUpdateManagerUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/GetAppUpdateManagerUseCase.java
@@ -1,6 +1,6 @@
 package com.d4rk.androidtutorials.java.domain.main;
 
-import com.d4rk.androidtutorials.java.ui.screens.main.repository.MainRepository;
+import com.d4rk.androidtutorials.java.data.repository.MainRepository;
 import com.google.android.play.core.appupdate.AppUpdateManager;
 
 /** Provides the AppUpdateManager instance. */

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/GetBottomNavLabelVisibilityUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/GetBottomNavLabelVisibilityUseCase.java
@@ -1,6 +1,6 @@
 package com.d4rk.androidtutorials.java.domain.main;
 
-import com.d4rk.androidtutorials.java.ui.screens.main.repository.MainRepository;
+import com.d4rk.androidtutorials.java.data.repository.MainRepository;
 
 /** Returns bottom navigation label visibility preference. */
 public class GetBottomNavLabelVisibilityUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/GetDefaultTabPreferenceUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/GetDefaultTabPreferenceUseCase.java
@@ -1,6 +1,6 @@
 package com.d4rk.androidtutorials.java.domain.main;
 
-import com.d4rk.androidtutorials.java.ui.screens.main.repository.MainRepository;
+import com.d4rk.androidtutorials.java.data.repository.MainRepository;
 
 /** Returns the default tab preference string. */
 public class GetDefaultTabPreferenceUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/IsAppInstalledUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/IsAppInstalledUseCase.java
@@ -1,7 +1,7 @@
 package com.d4rk.androidtutorials.java.domain.main;
 
 import android.content.pm.PackageManager;
-import com.d4rk.androidtutorials.java.ui.screens.main.repository.MainRepository;
+import com.d4rk.androidtutorials.java.data.repository.MainRepository;
 
 /** Checks if an app is installed by package name. */
 public class IsAppInstalledUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/MarkStartupScreenShownUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/MarkStartupScreenShownUseCase.java
@@ -1,6 +1,6 @@
 package com.d4rk.androidtutorials.java.domain.main;
 
-import com.d4rk.androidtutorials.java.ui.screens.main.repository.MainRepository;
+import com.d4rk.androidtutorials.java.data.repository.MainRepository;
 
 /** Marks that the startup screen has been shown. */
 public class MarkStartupScreenShownUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/ShouldShowStartupScreenUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/ShouldShowStartupScreenUseCase.java
@@ -1,6 +1,6 @@
 package com.d4rk.androidtutorials.java.domain.main;
 
-import com.d4rk.androidtutorials.java.ui.screens.main.repository.MainRepository;
+import com.d4rk.androidtutorials.java.data.repository.MainRepository;
 
 /** Determines if the startup screen should be shown. */
 public class ShouldShowStartupScreenUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/settings/ApplyConsentUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/settings/ApplyConsentUseCase.java
@@ -1,6 +1,6 @@
 package com.d4rk.androidtutorials.java.domain.settings;
 
-import com.d4rk.androidtutorials.java.ui.screens.settings.repository.SettingsRepository;
+import com.d4rk.androidtutorials.java.data.repository.SettingsRepository;
 
 /** Applies the Firebase consent settings. */
 public class ApplyConsentUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/settings/GetSharedPreferencesUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/settings/GetSharedPreferencesUseCase.java
@@ -1,7 +1,7 @@
 package com.d4rk.androidtutorials.java.domain.settings;
 
 import android.content.SharedPreferences;
-import com.d4rk.androidtutorials.java.ui.screens.settings.repository.SettingsRepository;
+import com.d4rk.androidtutorials.java.data.repository.SettingsRepository;
 
 /** Provides shared preferences used by the settings screen. */
 public class GetSharedPreferencesUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/settings/OnPreferenceChangedUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/settings/OnPreferenceChangedUseCase.java
@@ -1,6 +1,6 @@
 package com.d4rk.androidtutorials.java.domain.settings;
 
-import com.d4rk.androidtutorials.java.ui.screens.settings.repository.SettingsRepository;
+import com.d4rk.androidtutorials.java.data.repository.SettingsRepository;
 
 /** Handles a preference change and returns true if theme changed. */
 public class OnPreferenceChangedUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/startup/LoadConsentFormUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/startup/LoadConsentFormUseCase.java
@@ -1,7 +1,7 @@
 package com.d4rk.androidtutorials.java.domain.startup;
 
 import android.app.Activity;
-import com.d4rk.androidtutorials.java.ui.screens.startup.repository.StartupRepository;
+import com.d4rk.androidtutorials.java.data.repository.StartupRepository;
 
 /** Loads and shows the consent form if required. */
 public class LoadConsentFormUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/startup/RequestConsentInfoUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/startup/RequestConsentInfoUseCase.java
@@ -1,7 +1,7 @@
 package com.d4rk.androidtutorials.java.domain.startup;
 
 import android.app.Activity;
-import com.d4rk.androidtutorials.java.ui.screens.startup.repository.StartupRepository;
+import com.d4rk.androidtutorials.java.data.repository.StartupRepository;
 import com.google.android.ump.ConsentRequestParameters;
 
 /** Requests consent info update via UMP. */

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/support/InitBillingClientUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/support/InitBillingClientUseCase.java
@@ -1,6 +1,6 @@
 package com.d4rk.androidtutorials.java.domain.support;
 
-import com.d4rk.androidtutorials.java.ui.screens.support.repository.SupportRepository;
+import com.d4rk.androidtutorials.java.data.repository.SupportRepository;
 
 /** Initializes billing client and invokes callback when connected. */
 public class InitBillingClientUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/support/InitMobileAdsUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/support/InitMobileAdsUseCase.java
@@ -1,7 +1,7 @@
 package com.d4rk.androidtutorials.java.domain.support;
 
 import com.d4rk.androidtutorials.java.databinding.ActivitySupportBinding;
-import com.d4rk.androidtutorials.java.ui.screens.support.repository.SupportRepository;
+import com.d4rk.androidtutorials.java.data.repository.SupportRepository;
 
 /** Initializes Google Mobile Ads. */
 public class InitMobileAdsUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/support/InitiatePurchaseUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/support/InitiatePurchaseUseCase.java
@@ -1,7 +1,7 @@
 package com.d4rk.androidtutorials.java.domain.support;
 
 import android.app.Activity;
-import com.d4rk.androidtutorials.java.ui.screens.support.repository.SupportRepository;
+import com.d4rk.androidtutorials.java.data.repository.SupportRepository;
 
 /** Launches billing flow for a product. */
 public class InitiatePurchaseUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/support/QueryProductDetailsUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/support/QueryProductDetailsUseCase.java
@@ -1,7 +1,7 @@
 package com.d4rk.androidtutorials.java.domain.support;
 
 import java.util.List;
-import com.d4rk.androidtutorials.java.ui.screens.support.repository.SupportRepository;
+import com.d4rk.androidtutorials.java.data.repository.SupportRepository;
 
 /** Queries in-app product details. */
 public class QueryProductDetailsUseCase {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/about/repository/AboutRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/about/repository/AboutRepository.java
@@ -12,7 +12,7 @@ import java.util.Locale;
 /**
  * Repository for the "About" screen. Provides version info, date strings, etc.
  */
-public class AboutRepository {
+public class AboutRepository implements com.d4rk.androidtutorials.java.data.repository.AboutRepository {
 
     private final Context context;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/repository/LessonRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/repository/LessonRepository.java
@@ -2,48 +2,46 @@ package com.d4rk.androidtutorials.java.ui.screens.android.repository;
 
 import com.d4rk.androidtutorials.java.R;
 
-public class LessonRepository {
+public class LessonRepository implements com.d4rk.androidtutorials.java.data.repository.LessonRepository {
 
-    public record Lesson(int titleResId, int codeResId, int layoutResId) { }
-
-    public Lesson getLesson(String lessonName) {
+    public com.d4rk.androidtutorials.java.data.repository.LessonRepository.Lesson getLesson(String lessonName) {
         return switch (lessonName) {
             case "AlertDialog" ->
-                    new Lesson(R.string.alert_dialog, R.raw.text_alertdialog_java, R.raw.text_center_button_xml);
+                    new com.d4rk.androidtutorials.java.data.repository.LessonRepository.Lesson(R.string.alert_dialog, R.raw.text_alertdialog_java, R.raw.text_center_button_xml);
             case "SnackBar" ->
-                    new Lesson(R.string.snack_bar, R.raw.text_snack_bar_java, R.raw.text_center_button_xml);
+                    new com.d4rk.androidtutorials.java.data.repository.LessonRepository.Lesson(R.string.snack_bar, R.raw.text_snack_bar_java, R.raw.text_center_button_xml);
             case "Toast" ->
-                    new Lesson(R.string.toast, R.raw.text_toast_java, R.raw.text_center_button_xml);
+                    new com.d4rk.androidtutorials.java.data.repository.LessonRepository.Lesson(R.string.toast, R.raw.text_toast_java, R.raw.text_center_button_xml);
             case "ImageButtons" ->
-                    new Lesson(R.string.image_buttons, R.raw.text_image_buttons_java, R.raw.text_image_buttons_xml);
+                    new com.d4rk.androidtutorials.java.data.repository.LessonRepository.Lesson(R.string.image_buttons, R.raw.text_image_buttons_java, R.raw.text_image_buttons_xml);
             case "RadioButtons" ->
-                    new Lesson(R.string.radio_buttons, R.raw.text_radio_buttons_java, R.raw.text_radio_buttons_xml);
+                    new com.d4rk.androidtutorials.java.data.repository.LessonRepository.Lesson(R.string.radio_buttons, R.raw.text_radio_buttons_java, R.raw.text_radio_buttons_xml);
             case "Switch" ->
-                    new Lesson(R.string.switches, R.raw.text_toggle_java, R.raw.text_toggle_xml);
+                    new com.d4rk.androidtutorials.java.data.repository.LessonRepository.Lesson(R.string.switches, R.raw.text_toggle_java, R.raw.text_toggle_xml);
             case "Chronometer" ->
-                    new Lesson(R.string.chronometer, R.raw.text_chronometer_java, R.raw.text_chronometer_layout_xml);
+                    new com.d4rk.androidtutorials.java.data.repository.LessonRepository.Lesson(R.string.chronometer, R.raw.text_chronometer_java, R.raw.text_chronometer_layout_xml);
             case "DatePicker" ->
-                    new Lesson(R.string.datepicker, R.raw.text_datepicker_java, R.raw.text_datepicker_xml);
+                    new com.d4rk.androidtutorials.java.data.repository.LessonRepository.Lesson(R.string.datepicker, R.raw.text_datepicker_java, R.raw.text_datepicker_xml);
             case "TimePicker" ->
-                    new Lesson(R.string.timepicker, R.raw.text_timepicker_java, R.raw.text_timepicker_xml);
+                    new com.d4rk.androidtutorials.java.data.repository.LessonRepository.Lesson(R.string.timepicker, R.raw.text_timepicker_java, R.raw.text_timepicker_xml);
             case "InboxNotification" ->
-                    new Lesson(R.string.inbox_notifications, R.raw.text_inbox_notification_java, R.raw.text_center_button_xml);
+                    new com.d4rk.androidtutorials.java.data.repository.LessonRepository.Lesson(R.string.inbox_notifications, R.raw.text_inbox_notification_java, R.raw.text_center_button_xml);
             case "SimpleNotification" ->
-                    new Lesson(R.string.simple_notifications, R.raw.text_simple_notification_java, R.raw.text_center_button_xml);
+                    new com.d4rk.androidtutorials.java.data.repository.LessonRepository.Lesson(R.string.simple_notifications, R.raw.text_simple_notification_java, R.raw.text_center_button_xml);
             case "RatingBar" ->
-                    new Lesson(R.string.rating_bar, R.raw.text_rating_bar_java, R.raw.text_rating_bar_xml);
+                    new com.d4rk.androidtutorials.java.data.repository.LessonRepository.Lesson(R.string.rating_bar, R.raw.text_rating_bar_java, R.raw.text_rating_bar_xml);
             case "PasswordBox" ->
-                    new Lesson(R.string.password_box, R.raw.text_password_java, R.raw.text_password_xml);
+                    new com.d4rk.androidtutorials.java.data.repository.LessonRepository.Lesson(R.string.password_box, R.raw.text_password_java, R.raw.text_password_xml);
             case "TextBox" ->
-                    new Lesson(R.string.textbox, R.raw.text_textbox_java, R.raw.text_textbox_xml);
+                    new com.d4rk.androidtutorials.java.data.repository.LessonRepository.Lesson(R.string.textbox, R.raw.text_textbox_java, R.raw.text_textbox_xml);
             case "GridView" ->
-                    new Lesson(R.string.grid_view, R.raw.text_grid_view_java, R.raw.text_grid_view_xml);
+                    new com.d4rk.androidtutorials.java.data.repository.LessonRepository.Lesson(R.string.grid_view, R.raw.text_grid_view_java, R.raw.text_grid_view_xml);
             case "WebView" ->
-                    new Lesson(R.string.web_view, R.raw.text_webview_java, R.raw.text_webview_xml);
+                    new com.d4rk.androidtutorials.java.data.repository.LessonRepository.Lesson(R.string.web_view, R.raw.text_webview_java, R.raw.text_webview_xml);
             case "BottomNavigation" ->
-                    new Lesson(R.string.bottom_navigation, R.raw.text_bottom_navigation_java, R.raw.text_bottom_navigation_xml);
+                    new com.d4rk.androidtutorials.java.data.repository.LessonRepository.Lesson(R.string.bottom_navigation, R.raw.text_bottom_navigation_java, R.raw.text_bottom_navigation_xml);
             case "NavigationDrawer" ->
-                    new Lesson(R.string.navigation_drawer, R.raw.text_navigation_drawer_java, R.raw.text_navigation_drawer_xml);
+                    new com.d4rk.androidtutorials.java.data.repository.LessonRepository.Lesson(R.string.navigation_drawer, R.raw.text_navigation_drawer_java, R.raw.text_navigation_drawer_xml);
             default -> throw new IllegalArgumentException("Unknown lesson: " + lessonName);
         };
     }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/help/repository/HelpRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/help/repository/HelpRepository.java
@@ -12,7 +12,7 @@ import com.google.android.play.core.review.ReviewManagerFactory;
 /**
  * Repository for the Help screen. Manages the ReviewManager and in-app review flow.
  */
-public class HelpRepository {
+public class HelpRepository implements com.d4rk.androidtutorials.java.data.repository.HelpRepository {
 
     private final ReviewManager reviewManager;
 
@@ -25,7 +25,7 @@ public class HelpRepository {
      * onSuccess -> returns the ReviewInfo to the caller
      * onFailure -> callback with exception
      */
-    public void requestReviewFlow(@NonNull OnReviewInfoListener listener) {
+    public void requestReviewFlow(@NonNull com.d4rk.androidtutorials.java.data.repository.HelpRepository.OnReviewInfoListener listener) {
         reviewManager.requestReviewFlow()
                 .addOnSuccessListener(listener::onSuccess)
                 .addOnFailureListener(listener::onFailure);
@@ -42,13 +42,4 @@ public class HelpRepository {
         reviewManager.launchReviewFlow(activity, reviewInfo);
     }
 
-    /**
-     * Simple callback interface to deliver success or failure
-     * when requesting a ReviewFlow.
-     */
-    public interface OnReviewInfoListener {
-        void onSuccess(ReviewInfo info);
-
-        void onFailure(Exception e);
-    }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/repository/MainRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/repository/MainRepository.java
@@ -18,7 +18,7 @@ import com.google.android.play.core.appupdate.AppUpdateManagerFactory;
  * Repository class that handles data operations such as SharedPreferences,
  * app update checks, etc.
  */
-public class MainRepository {
+public class MainRepository implements com.d4rk.androidtutorials.java.data.repository.MainRepository {
 
     private final Context context;
     private final SharedPreferences defaultSharedPrefs;

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/settings/repository/SettingsRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/settings/repository/SettingsRepository.java
@@ -16,7 +16,7 @@ import com.d4rk.androidtutorials.java.R;
  * Repository that handles reading/writing preferences (e.g., theme, language)
  * and applies the changes (e.g., calls setDefaultNightMode).
  */
-public class SettingsRepository {
+public class SettingsRepository implements com.d4rk.androidtutorials.java.data.repository.SettingsRepository {
 
     private final Context context;
     private final SharedPreferences sharedPreferences;

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/startup/repository/StartupRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/startup/repository/StartupRepository.java
@@ -13,7 +13,7 @@ import com.google.android.ump.UserMessagingPlatform;
  * Repository that handles consent logic for the startup screen.
  * It keeps references to ConsentInformation and ConsentForm.
  */
-public class StartupRepository {
+public class StartupRepository implements com.d4rk.androidtutorials.java.data.repository.StartupRepository {
 
     private final ConsentInformation consentInformation;
     private ConsentForm consentForm;
@@ -33,7 +33,7 @@ public class StartupRepository {
     public void requestConsentInfoUpdate(Activity activity,
                                          ConsentRequestParameters params,
                                          Runnable onSuccess,
-                                         OnFormError onError) {
+                                         com.d4rk.androidtutorials.java.data.repository.StartupRepository.OnFormError onError) {
         consentInformation.requestConsentInfoUpdate(
                 activity,
                 params,
@@ -55,7 +55,7 @@ public class StartupRepository {
      * @param activity the current Activity
      * @param onError  callback invoked if there's a problem loading or showing the form
      */
-    public void loadConsentForm(Activity activity, OnFormError onError) {
+    public void loadConsentForm(Activity activity, com.d4rk.androidtutorials.java.data.repository.StartupRepository.OnFormError onError) {
         UserMessagingPlatform.loadConsentForm(
                 activity,
                 form -> {
@@ -76,10 +76,4 @@ public class StartupRepository {
         );
     }
 
-    /**
-     * Simple functional interface for delivering form errors back to the caller.
-     */
-    public interface OnFormError {
-        void onFormError(FormError error);
-    }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/support/repository/SupportRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/support/repository/SupportRepository.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class SupportRepository {
+public class SupportRepository implements com.d4rk.androidtutorials.java.data.repository.SupportRepository {
 
     private final Context context;
     private final Map<String, ProductDetails> productDetailsMap = new HashMap<>();
@@ -74,7 +74,7 @@ public class SupportRepository {
      * Query your product details for in-app items.
      * Typically called after billing client is connected.
      */
-    public void queryProductDetails(List<String> productIds, OnProductDetailsListener listener) {
+    public void queryProductDetails(List<String> productIds, com.d4rk.androidtutorials.java.data.repository.SupportRepository.OnProductDetailsListener listener) {
         if (billingClient == null || !billingClient.isReady()) {
             return;
         }
@@ -158,10 +158,4 @@ public class SupportRepository {
         binding.largeBannerAd.loadAd(new AdRequest.Builder().build());
     }
 
-    /**
-     * Callback interface for when product details are fetched.
-     */
-    public interface OnProductDetailsListener {
-        void onProductDetailsRetrieved(List<ProductDetails> productDetailsList);
-    }
 }


### PR DESCRIPTION
## Summary
- define repository interfaces in `data/repository` and implement them in UI layer
- update domain use cases to depend on repository interfaces rather than UI implementations

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b374af3140832d8cd2ab3fe9d7e534