### PR TITLE
Refactor Home repository to remove Android dependencies

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/DefaultHomeRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/DefaultHomeRepository.java
@@ -2,10 +2,7 @@ package com.d4rk.androidtutorials.java.data.repository;
 
 import com.d4rk.androidtutorials.java.data.source.HomeLocalDataSource;
 import com.d4rk.androidtutorials.java.data.source.HomeRemoteDataSource;
-import com.d4rk.androidtutorials.java.data.model.PromotedApp;
-
-import java.util.List;
-import java.util.function.Consumer;
+import com.d4rk.androidtutorials.java.data.repository.HomeRepository.PromotedAppsCallback;
 
 /**
  * Default implementation of {@link HomeRepository} combining local and remote sources.
@@ -37,7 +34,7 @@ public class DefaultHomeRepository implements HomeRepository {
     }
 
     @Override
-    public void fetchPromotedApps(Consumer<List<PromotedApp>> callback) {
-        remoteDataSource.fetchPromotedApps(callback::accept);
+    public void fetchPromotedApps(PromotedAppsCallback callback) {
+        remoteDataSource.fetchPromotedApps(callback::onResult);
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/DefaultHomeRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/DefaultHomeRepository.java
@@ -1,10 +1,11 @@
 package com.d4rk.androidtutorials.java.data.repository;
 
-import android.content.Intent;
-
 import com.d4rk.androidtutorials.java.data.source.HomeLocalDataSource;
 import com.d4rk.androidtutorials.java.data.source.HomeRemoteDataSource;
-import com.d4rk.androidtutorials.java.data.source.HomeRemoteDataSource.PromotedAppsCallback;
+import com.d4rk.androidtutorials.java.data.model.PromotedApp;
+
+import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Default implementation of {@link HomeRepository} combining local and remote sources.
@@ -21,13 +22,13 @@ public class DefaultHomeRepository implements HomeRepository {
     }
 
     @Override
-    public Intent getPlayStoreIntent() {
-        return localDataSource.getPlayStoreIntent();
+    public String getPlayStoreUrl() {
+        return localDataSource.getPlayStoreUrl();
     }
 
     @Override
-    public Intent getAppPlayStoreIntent(String packageName) {
-        return localDataSource.getAppPlayStoreIntent(packageName);
+    public String getAppPlayStoreUrl(String packageName) {
+        return localDataSource.getAppPlayStoreUrl(packageName);
     }
 
     @Override
@@ -36,7 +37,7 @@ public class DefaultHomeRepository implements HomeRepository {
     }
 
     @Override
-    public void fetchPromotedApps(PromotedAppsCallback callback) {
-        remoteDataSource.fetchPromotedApps(callback);
+    public void fetchPromotedApps(Consumer<List<PromotedApp>> callback) {
+        remoteDataSource.fetchPromotedApps(callback::accept);
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/HomeRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/HomeRepository.java
@@ -1,20 +1,19 @@
 package com.d4rk.androidtutorials.java.data.repository;
 
-import android.content.Intent;
-
 import com.d4rk.androidtutorials.java.data.model.PromotedApp;
-import com.d4rk.androidtutorials.java.data.source.HomeRemoteDataSource.PromotedAppsCallback;
+import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Abstraction over home data operations.
  */
 public interface HomeRepository {
 
-    Intent getPlayStoreIntent();
+    String getPlayStoreUrl();
 
-    Intent getAppPlayStoreIntent(String packageName);
+    String getAppPlayStoreUrl(String packageName);
 
     String getDailyTip();
 
-    void fetchPromotedApps(PromotedAppsCallback callback);
+    void fetchPromotedApps(Consumer<List<PromotedApp>> callback);
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/HomeRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/HomeRepository.java
@@ -2,7 +2,6 @@ package com.d4rk.androidtutorials.java.data.repository;
 
 import com.d4rk.androidtutorials.java.data.model.PromotedApp;
 import java.util.List;
-import java.util.function.Consumer;
 
 /**
  * Abstraction over home data operations.
@@ -15,5 +14,9 @@ public interface HomeRepository {
 
     String getDailyTip();
 
-    void fetchPromotedApps(Consumer<List<PromotedApp>> callback);
+    void fetchPromotedApps(PromotedAppsCallback callback);
+
+    interface PromotedAppsCallback {
+        void onResult(List<PromotedApp> apps);
+    }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/source/DefaultHomeLocalDataSource.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/source/DefaultHomeLocalDataSource.java
@@ -1,8 +1,6 @@
 package com.d4rk.androidtutorials.java.data.source;
 
 import android.content.Context;
-import android.content.Intent;
-import android.net.Uri;
 
 import com.d4rk.androidtutorials.java.R;
 
@@ -18,15 +16,13 @@ public class DefaultHomeLocalDataSource implements HomeLocalDataSource {
     }
 
     @Override
-    public Intent getPlayStoreIntent() {
-        String playStoreUrl = "https://play.google.com/store/apps/details?id=com.d4rk.androidtutorials";
-        return buildPlayStoreIntent(playStoreUrl);
+    public String getPlayStoreUrl() {
+        return "https://play.google.com/store/apps/details?id=com.d4rk.androidtutorials";
     }
 
     @Override
-    public Intent getAppPlayStoreIntent(String packageName) {
-        String url = "https://play.google.com/store/apps/details?id=" + packageName;
-        return buildPlayStoreIntent(url);
+    public String getAppPlayStoreUrl(String packageName) {
+        return "https://play.google.com/store/apps/details?id=" + packageName;
     }
 
     @Override
@@ -37,12 +33,4 @@ public class DefaultHomeLocalDataSource implements HomeLocalDataSource {
         return tips[index];
     }
 
-    private Intent buildPlayStoreIntent(String url) {
-        Intent playStoreIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-        playStoreIntent.setPackage("com.android.vending");
-        if (playStoreIntent.resolveActivity(context.getPackageManager()) != null) {
-            return playStoreIntent;
-        }
-        return new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-    }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/source/HomeLocalDataSource.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/source/HomeLocalDataSource.java
@@ -1,15 +1,13 @@
 package com.d4rk.androidtutorials.java.data.source;
 
-import android.content.Intent;
-
 /**
  * Local data access for the home feature.
  */
 public interface HomeLocalDataSource {
 
-    Intent getPlayStoreIntent();
+    String getPlayStoreUrl();
 
-    Intent getAppPlayStoreIntent(String packageName);
+    String getAppPlayStoreUrl(String packageName);
 
     String getDailyTip();
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeViewModel.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeViewModel.java
@@ -2,6 +2,7 @@ package com.d4rk.androidtutorials.java.ui.screens.home;
 
 import android.app.Application;
 import android.content.Intent;
+import android.net.Uri;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.AndroidViewModel;
@@ -90,7 +91,7 @@ public class HomeViewModel extends AndroidViewModel {
      * The HomeFragment can startActivity(...) on it.
      */
     public Intent getOpenPlayStoreIntent() {
-        return homeRepository.getPlayStoreIntent();
+        return buildPlayStoreIntent(homeRepository.getPlayStoreUrl());
     }
 
     /**
@@ -104,6 +105,15 @@ public class HomeViewModel extends AndroidViewModel {
      * Builds an intent to open the Google Play listing for the provided package.
      */
     public Intent getPromotedAppIntent(String packageName) {
-        return homeRepository.getAppPlayStoreIntent(packageName);
+        return buildPlayStoreIntent(homeRepository.getAppPlayStoreUrl(packageName));
+    }
+
+    private Intent buildPlayStoreIntent(String url) {
+        Intent playStoreIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+        playStoreIntent.setPackage("com.android.vending");
+        if (playStoreIntent.resolveActivity(getApplication().getPackageManager()) != null) {
+            return playStoreIntent;
+        }
+        return new Intent(Intent.ACTION_VIEW, Uri.parse(url));
     }
 }


### PR DESCRIPTION
## Summary
- Move Android-specific logic into local/remote data sources
- Expose plain URL strings from Home repository
- Build Play Store intents in HomeViewModel

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b379ecc464832db22aa1fbe33f2d03