### PR TITLE
Refactor home screen state management

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeUiState.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeUiState.java
@@ -1,0 +1,16 @@
+package com.d4rk.androidtutorials.java.ui.screens.home;
+
+import java.util.List;
+
+import com.d4rk.androidtutorials.java.data.model.PromotedApp;
+
+/**
+ * Represents the UI state for the Home screen.
+ */
+public record HomeUiState(
+        String announcementTitle,
+        String announcementSubtitle,
+        String dailyTip,
+        List<PromotedApp> promotedApps
+) {}
+


### PR DESCRIPTION
## Summary
- Introduce `HomeUiState` to encapsulate home screen data
- Replace multiple `LiveData` fields with single `MutableLiveData<HomeUiState>` in `HomeViewModel`
- Update `HomeFragment` to observe `uiState` and render home content

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b404a56ea0832db9e477103fbafc55