### PR TITLE
Annotate screens for Hilt view model injection

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/about/AboutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/about/AboutFragment.java
@@ -22,6 +22,9 @@ import com.google.android.gms.ads.MobileAds;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
 public class AboutFragment extends Fragment {
 
     private FragmentAboutBinding binding;

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/help/HelpActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/help/HelpActivity.java
@@ -27,6 +27,9 @@ import com.google.android.material.snackbar.Snackbar;
 import com.google.android.play.core.review.ReviewInfo;
 import com.mikepenz.aboutlibraries.LibsBuilder;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
 public class HelpActivity extends AppCompatActivity {
 
     private HelpViewModel helpViewModel;

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeFragment.java
@@ -16,6 +16,9 @@ import com.google.android.gms.ads.MobileAds;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
 public class HomeFragment extends Fragment {
 
     private FragmentHomeBinding binding;

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainActivity.java
@@ -55,7 +55,9 @@ import com.google.android.play.core.install.model.UpdateAvailability;
 import com.google.android.ump.ConsentInformation;
 import com.google.android.ump.ConsentRequestParameters;
 import com.google.android.ump.UserMessagingPlatform;
+import dagger.hilt.android.AndroidEntryPoint;
 
+@AndroidEntryPoint
 public class MainActivity extends AppCompatActivity {
 
     private final ActivityResultLauncher<IntentSenderRequest> updateActivityResultLauncher =

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/quiz/QuizActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/quiz/QuizActivity.java
@@ -21,6 +21,9 @@ import com.airbnb.lottie.LottieAnimationView;
 /**
  * Activity that displays a simple multiple-choice quiz.
  */
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
 public class QuizActivity extends AppCompatActivity {
 
     private ActivityQuizBinding binding;

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/settings/SettingsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/settings/SettingsActivity.java
@@ -16,6 +16,9 @@ import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 /**
  * Settings screen that delegates preference change logic to a ViewModel/Repository.
  */
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
 public class SettingsActivity extends AppCompatActivity
         implements SharedPreferences.OnSharedPreferenceChangeListener,
         androidx.preference.Preference.SummaryProvider<ListPreference> {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/startup/StartupActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/startup/StartupActivity.java
@@ -21,6 +21,9 @@ import com.d4rk.androidtutorials.java.utils.ConsentUtils;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
 public class StartupActivity extends AppCompatActivity {
 
     private StartupViewModel startupViewModel;

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/support/SupportActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/support/SupportActivity.java
@@ -16,6 +16,9 @@ import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 
 import java.util.List;
 
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
 public class SupportActivity extends AppCompatActivity {
 
     private ActivitySupportBinding binding;


### PR DESCRIPTION
## Summary
- annotate activities and fragments that use `@HiltViewModel` with `@AndroidEntryPoint`
- allow Hilt to construct view models without `NoSuchMethodException`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b407fd842c832d91b2063b060d509f