### PR TITLE
Set proper theme for AndroidStartProjectActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -290,6 +290,7 @@
             android:name=".ui.screens.android.lessons.start.AndroidStartProjectActivity"
             android:exported="false"
             android:label="@string/android_start"
+            android:theme="@style/AppTheme"
             android:parentActivityName=".ui.screens.android.lessons.start.AndroidStartProjectActivity" />
         <activity
             android:name=".ui.screens.android.lessons.basics.sdk.AndroidSDK"


### PR DESCRIPTION
## Summary
- avoid duplicate action bar crash by disabling the window action bar via AppTheme

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b409b55f50832da99ab6020b935fb0