### PR TITLE
Refactor support repository to remove Activity dependencies

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/model/AdLoadParams.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/model/AdLoadParams.java
@@ -1,17 +1,23 @@
 package com.d4rk.androidtutorials.java.data.model;
 
 import com.google.android.gms.ads.AdRequest;
-import java.util.function.Consumer;
 
 /** Parameters used to load an ad without exposing view bindings. */
 public class AdLoadParams {
-    private final Consumer<AdRequest> adLoader;
 
-    public AdLoadParams(Consumer<AdRequest> adLoader) {
+    /** Callback to handle ad loading without exposing view bindings. */
+    @FunctionalInterface
+    public interface AdLoader {
+        void load(AdRequest request);
+    }
+
+    private final AdLoader adLoader;
+
+    public AdLoadParams(AdLoader adLoader) {
         this.adLoader = adLoader;
     }
 
-    public Consumer<AdRequest> getAdLoader() {
+    public AdLoader getAdLoader() {
         return adLoader;
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/model/AdLoadParams.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/model/AdLoadParams.java
@@ -1,0 +1,18 @@
+package com.d4rk.androidtutorials.java.data.model;
+
+import com.google.android.gms.ads.AdRequest;
+import java.util.function.Consumer;
+
+/** Parameters used to load an ad without exposing view bindings. */
+public class AdLoadParams {
+    private final Consumer<AdRequest> adLoader;
+
+    public AdLoadParams(Consumer<AdRequest> adLoader) {
+        this.adLoader = adLoader;
+    }
+
+    public Consumer<AdRequest> getAdLoader() {
+        return adLoader;
+    }
+}
+

--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/SupportRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/SupportRepository.java
@@ -1,17 +1,22 @@
 package com.d4rk.androidtutorials.java.data.repository;
 
-import android.app.Activity;
+import com.android.billingclient.api.BillingClient;
+import com.android.billingclient.api.BillingFlowParams;
 import com.android.billingclient.api.ProductDetails;
-import com.d4rk.androidtutorials.java.databinding.ActivitySupportBinding;
+import com.d4rk.androidtutorials.java.data.model.AdLoadParams;
 import java.util.List;
 
 public interface SupportRepository {
     void initBillingClient(Runnable onConnected);
     void queryProductDetails(List<String> productIds, OnProductDetailsListener listener);
-    void initiatePurchase(Activity activity, String productId);
-    void initMobileAds(ActivitySupportBinding binding);
+    void initiatePurchase(String productId, BillingFlowLauncher launcher);
+    void initMobileAds(AdLoadParams params);
 
     interface OnProductDetailsListener {
         void onProductDetailsRetrieved(List<ProductDetails> productDetailsList);
+    }
+
+    interface BillingFlowLauncher {
+        void launch(BillingClient billingClient, BillingFlowParams params);
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/support/InitMobileAdsUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/support/InitMobileAdsUseCase.java
@@ -1,6 +1,6 @@
 package com.d4rk.androidtutorials.java.domain.support;
 
-import com.d4rk.androidtutorials.java.databinding.ActivitySupportBinding;
+import com.d4rk.androidtutorials.java.data.model.AdLoadParams;
 import com.d4rk.androidtutorials.java.data.repository.SupportRepository;
 
 /** Initializes Google Mobile Ads. */
@@ -11,7 +11,7 @@ public class InitMobileAdsUseCase {
         this.repository = repository;
     }
 
-    public void invoke(ActivitySupportBinding binding) {
-        repository.initMobileAds(binding);
+    public void invoke(AdLoadParams params) {
+        repository.initMobileAds(params);
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/support/InitiatePurchaseUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/support/InitiatePurchaseUseCase.java
@@ -1,6 +1,5 @@
 package com.d4rk.androidtutorials.java.domain.support;
 
-import android.app.Activity;
 import com.d4rk.androidtutorials.java.data.repository.SupportRepository;
 
 /** Launches billing flow for a product. */
@@ -11,7 +10,7 @@ public class InitiatePurchaseUseCase {
         this.repository = repository;
     }
 
-    public void invoke(Activity activity, String productId) {
-        repository.initiatePurchase(activity, productId);
+    public void invoke(String productId, SupportRepository.BillingFlowLauncher launcher) {
+        repository.initiatePurchase(productId, launcher);
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/support/SupportActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/support/SupportActivity.java
@@ -11,6 +11,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.android.billingclient.api.ProductDetails;
+import com.d4rk.androidtutorials.java.data.model.AdLoadParams;
 import com.d4rk.androidtutorials.java.databinding.ActivitySupportBinding;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 
@@ -41,7 +42,7 @@ public class SupportActivity extends AppCompatActivity {
 
         supportViewModel = new ViewModelProvider(this).get(SupportViewModel.class);
 
-        supportViewModel.initMobileAds(binding);
+        supportViewModel.initMobileAds(new AdLoadParams(adRequest -> binding.largeBannerAd.loadAd(adRequest)));
 
         binding.buttonWebAd.setOnClickListener(v ->
                 startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://bit.ly/3p8bpjj"))));
@@ -72,7 +73,8 @@ public class SupportActivity extends AppCompatActivity {
     }
 
     private void initiatePurchase(String productId) {
-        supportViewModel.initiatePurchase(this, productId);
+        supportViewModel.initiatePurchase(productId,
+                (billingClient, params) -> billingClient.launchBillingFlow(this, params));
     }
 
     @Override

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/support/SupportViewModel.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/support/SupportViewModel.java
@@ -1,15 +1,13 @@
 package com.d4rk.androidtutorials.java.ui.screens.support;
 
-import android.app.Activity;
-
 import androidx.lifecycle.ViewModel;
 
-import com.d4rk.androidtutorials.java.databinding.ActivitySupportBinding;
+import com.d4rk.androidtutorials.java.data.model.AdLoadParams;
+import com.d4rk.androidtutorials.java.data.repository.SupportRepository;
 import com.d4rk.androidtutorials.java.domain.support.InitBillingClientUseCase;
 import com.d4rk.androidtutorials.java.domain.support.QueryProductDetailsUseCase;
 import com.d4rk.androidtutorials.java.domain.support.InitiatePurchaseUseCase;
 import com.d4rk.androidtutorials.java.domain.support.InitMobileAdsUseCase;
-import com.d4rk.androidtutorials.java.ui.screens.support.repository.SupportRepository;
 
 import dagger.hilt.android.lifecycle.HiltViewModel;
 import javax.inject.Inject;
@@ -44,11 +42,11 @@ public class SupportViewModel extends ViewModel {
         queryProductDetailsUseCase.invoke(productIds, listener);
     }
 
-    public void initiatePurchase(Activity activity, String productId) {
-        initiatePurchaseUseCase.invoke(activity, productId);
+    public void initiatePurchase(String productId, SupportRepository.BillingFlowLauncher launcher) {
+        initiatePurchaseUseCase.invoke(productId, launcher);
     }
 
-    public void initMobileAds(ActivitySupportBinding binding) {
-        initMobileAdsUseCase.invoke(binding);
+    public void initMobileAds(AdLoadParams params) {
+        initMobileAdsUseCase.invoke(params);
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/support/repository/SupportRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/support/repository/SupportRepository.java
@@ -155,7 +155,7 @@ public class SupportRepository implements com.d4rk.androidtutorials.java.data.re
     public void initMobileAds(AdLoadParams params) {
         MobileAds.initialize(context);
         if (params != null && params.getAdLoader() != null) {
-            params.getAdLoader().accept(new AdRequest.Builder().build());
+            params.getAdLoader().load(new AdRequest.Builder().build());
         }
     }
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/support/repository/SupportRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/support/repository/SupportRepository.java
@@ -1,6 +1,5 @@
 package com.d4rk.androidtutorials.java.ui.screens.support.repository;
 
-import android.app.Activity;
 import android.content.Context;
 
 import androidx.annotation.NonNull;
@@ -12,7 +11,7 @@ import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.PendingPurchasesParams;
 import com.android.billingclient.api.ProductDetails;
 import com.android.billingclient.api.QueryProductDetailsParams;
-import com.d4rk.androidtutorials.java.databinding.ActivitySupportBinding;
+import com.d4rk.androidtutorials.java.data.model.AdLoadParams;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.MobileAds;
 
@@ -120,9 +119,9 @@ public class SupportRepository implements com.d4rk.androidtutorials.java.data.re
     /**
      * Launch the billing flow for a particular product.
      */
-    public void initiatePurchase(Activity activity, String productId) {
+    public void initiatePurchase(String productId, com.d4rk.androidtutorials.java.data.repository.SupportRepository.BillingFlowLauncher launcher) {
         ProductDetails details = productDetailsMap.get(productId);
-        if (details != null) {
+        if (details != null && billingClient != null && launcher != null) {
             // Note: In a real app, you would select a specific offer. For simplicity,
             // we're assuming there's only one or we're using the base plan.
             // For subscriptions, this would be ProductDetails.getSubscriptionOfferDetails()
@@ -144,7 +143,7 @@ public class SupportRepository implements com.d4rk.androidtutorials.java.data.re
                     .setProductDetailsParamsList(productDetailsParamsList)
                     .build();
 
-            billingClient.launchBillingFlow(activity, flowParams);
+            launcher.launch(billingClient, flowParams);
         }
     }
 
@@ -153,9 +152,11 @@ public class SupportRepository implements com.d4rk.androidtutorials.java.data.re
      * Initialize Mobile Ads (usually done once in your app, but
      * can be done here if needed for the support screen).
      */
-    public void initMobileAds(ActivitySupportBinding binding) {
+    public void initMobileAds(AdLoadParams params) {
         MobileAds.initialize(context);
-        binding.largeBannerAd.loadAd(new AdRequest.Builder().build());
+        if (params != null && params.getAdLoader() != null) {
+            params.getAdLoader().accept(new AdRequest.Builder().build());
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
- decouple SupportRepository from Activity and view binding by introducing callbacks and AdLoadParams data object
- update use cases, SupportViewModel, and SupportActivity to use new repository signatures

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b426e0cae0832d9eb3ebd93cc489ce