### PR TITLE
refactor: move MainRepository implementation

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/DefaultMainRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/DefaultMainRepository.java
@@ -1,4 +1,4 @@
-package com.d4rk.androidtutorials.java.ui.screens.main.repository;
+package com.d4rk.androidtutorials.java.data.repository;
 
 import android.content.Context;
 import android.content.Intent;
@@ -18,13 +18,13 @@ import com.google.android.play.core.appupdate.AppUpdateManagerFactory;
  * Repository class that handles data operations such as SharedPreferences,
  * app update checks, etc.
  */
-public class MainRepository implements com.d4rk.androidtutorials.java.data.repository.MainRepository {
+public class DefaultMainRepository implements MainRepository {
 
     private final Context context;
     private final SharedPreferences defaultSharedPrefs;
     private final AppUpdateManager appUpdateManager;
 
-    public MainRepository(Context context) {
+    public DefaultMainRepository(Context context) {
         this.context = context.getApplicationContext();
         this.defaultSharedPrefs = PreferenceManager.getDefaultSharedPreferences(context);
         this.appUpdateManager = AppUpdateManagerFactory.create(this.context);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/di/AppModule.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/di/AppModule.java
@@ -6,8 +6,10 @@ import android.content.res.AssetManager;
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.Volley;
 import com.d4rk.androidtutorials.java.data.repository.DefaultHomeRepository;
+import com.d4rk.androidtutorials.java.data.repository.DefaultMainRepository;
 import com.d4rk.androidtutorials.java.data.repository.DefaultQuizRepository;
 import com.d4rk.androidtutorials.java.data.repository.HomeRepository;
+import com.d4rk.androidtutorials.java.data.repository.MainRepository;
 import com.d4rk.androidtutorials.java.data.repository.QuizRepository;
 import com.d4rk.androidtutorials.java.data.source.DefaultHomeLocalDataSource;
 import com.d4rk.androidtutorials.java.data.source.DefaultHomeRemoteDataSource;
@@ -42,7 +44,6 @@ import com.d4rk.androidtutorials.java.domain.support.InitiatePurchaseUseCase;
 import com.d4rk.androidtutorials.java.domain.support.QueryProductDetailsUseCase;
 import com.d4rk.androidtutorials.java.ui.screens.about.repository.AboutRepository;
 import com.d4rk.androidtutorials.java.ui.screens.help.repository.HelpRepository;
-import com.d4rk.androidtutorials.java.ui.screens.main.repository.MainRepository;
 import com.d4rk.androidtutorials.java.ui.screens.settings.repository.SettingsRepository;
 import com.d4rk.androidtutorials.java.ui.screens.startup.repository.StartupRepository;
 import com.d4rk.androidtutorials.java.ui.screens.support.repository.SupportRepository;
@@ -121,7 +122,7 @@ public class AppModule {
     @Provides
     @Singleton
     public MainRepository provideMainRepository(Application application) {
-        return new MainRepository(application);
+        return new DefaultMainRepository(application);
     }
 
     @Provides


### PR DESCRIPTION
## Summary
- move MainRepository implementation into data layer as DefaultMainRepository
- update DI to bind DefaultMainRepository to MainRepository

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b42d95cb70832d81365ad34dcaaa34