### PR TITLE
Decouple MainViewModel from Application context

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/DefaultMainRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/DefaultMainRepository.java
@@ -50,11 +50,11 @@ public class DefaultMainRepository implements MainRepository {
     /**
      * Check if a given package name is installed.
      *
-     * @param packageManager The PackageManager used to check installations.
-     * @param packageName    The package to check.
+     * @param packageName The package to check.
      * @return True if installed, false otherwise.
      */
-    public boolean isAppInstalled(PackageManager packageManager, String packageName) {
+    public boolean isAppInstalled(String packageName) {
+        PackageManager packageManager = context.getPackageManager();
         try {
             packageManager.getPackageInfo(packageName, 0);
             return true;
@@ -85,14 +85,18 @@ public class DefaultMainRepository implements MainRepository {
     /**
      * Retrieves the bottom navigation label visibility preference.
      */
-    public String getBottomNavLabelVisibility(String labelKey, String labelDefaultValue) {
+    public String getBottomNavLabelVisibility() {
+        String labelKey = context.getString(R.string.key_bottom_navigation_bar_labels);
+        String labelDefaultValue = context.getString(R.string.default_value_bottom_navigation_bar_labels);
         return defaultSharedPrefs.getString(labelKey, labelDefaultValue);
     }
 
     /**
      * Retrieves which tab should be shown by default.
      */
-    public String getDefaultTabPreference(String defaultTabKey, String defaultTabValue) {
+    public String getDefaultTabPreference() {
+        String defaultTabKey = context.getString(R.string.key_default_tab);
+        String defaultTabValue = context.getString(R.string.default_value_tab);
         return defaultSharedPrefs.getString(defaultTabKey, defaultTabValue);
     }
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/MainRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/MainRepository.java
@@ -1,14 +1,13 @@
 package com.d4rk.androidtutorials.java.data.repository;
 
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import com.google.android.play.core.appupdate.AppUpdateManager;
 
 public interface MainRepository {
-    boolean isAppInstalled(PackageManager packageManager, String packageName);
+    boolean isAppInstalled(String packageName);
     boolean applyThemeSettings(String[] darkModeValues);
-    String getBottomNavLabelVisibility(String labelKey, String labelDefaultValue);
-    String getDefaultTabPreference(String defaultTabKey, String defaultTabValue);
+    String getBottomNavLabelVisibility();
+    String getDefaultTabPreference();
     boolean shouldShowStartupScreen();
     void markStartupScreenShown();
     void applyLanguageSettings();

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/GetBottomNavLabelVisibilityUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/GetBottomNavLabelVisibilityUseCase.java
@@ -10,7 +10,7 @@ public class GetBottomNavLabelVisibilityUseCase {
         this.repository = repository;
     }
 
-    public String invoke(String key, String defaultValue) {
-        return repository.getBottomNavLabelVisibility(key, defaultValue);
+    public String invoke() {
+        return repository.getBottomNavLabelVisibility();
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/GetDefaultTabPreferenceUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/GetDefaultTabPreferenceUseCase.java
@@ -10,7 +10,7 @@ public class GetDefaultTabPreferenceUseCase {
         this.repository = repository;
     }
 
-    public String invoke(String key, String defaultValue) {
-        return repository.getDefaultTabPreference(key, defaultValue);
+    public String invoke() {
+        return repository.getDefaultTabPreference();
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/IsAppInstalledUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/main/IsAppInstalledUseCase.java
@@ -1,6 +1,5 @@
 package com.d4rk.androidtutorials.java.domain.main;
 
-import android.content.pm.PackageManager;
 import com.d4rk.androidtutorials.java.data.repository.MainRepository;
 
 /** Checks if an app is installed by package name. */
@@ -11,7 +10,7 @@ public class IsAppInstalledUseCase {
         this.repository = repository;
     }
 
-    public boolean invoke(PackageManager pm, String packageName) {
-        return repository.isAppInstalled(pm, packageName);
+    public boolean invoke(String packageName) {
+        return repository.isAppInstalled(packageName);
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainActivity.java
@@ -127,7 +127,10 @@ public class MainActivity extends AppCompatActivity {
 
         setupUpdateNotifications();
 
-        mainViewModel.applySettings();
+        String[] themeValues = getResources().getStringArray(R.array.preference_theme_values);
+        String[] bottomNavBarLabelsValues = getResources().getStringArray(R.array.preference_bottom_navigation_bar_labels_values);
+        String[] defaultTabValues = getResources().getStringArray(R.array.preference_default_tab_values);
+        mainViewModel.applySettings(themeValues, bottomNavBarLabelsValues, defaultTabValues);
         if (mainViewModel.shouldShowStartupScreen()) {
             mainViewModel.markStartupScreenShown();
             startActivity(new Intent(this, StartupActivity.class));

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainViewModel.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainViewModel.java
@@ -1,8 +1,6 @@
 package com.d4rk.androidtutorials.java.ui.screens.main;
 
-import android.app.Application;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.LiveData;
@@ -31,7 +29,6 @@ import javax.inject.Inject;
 @HiltViewModel
 public class MainViewModel extends ViewModel {
 
-    private final Application application;
     private final ApplyThemeSettingsUseCase applyThemeSettingsUseCase;
     private final GetBottomNavLabelVisibilityUseCase getBottomNavLabelVisibilityUseCase;
     private final GetDefaultTabPreferenceUseCase getDefaultTabPreferenceUseCase;
@@ -46,8 +43,7 @@ public class MainViewModel extends ViewModel {
     private final MutableLiveData<Boolean> themeChanged = new MutableLiveData<>();
 
     @Inject
-    public MainViewModel(Application application,
-                         ApplyThemeSettingsUseCase applyThemeSettingsUseCase,
+    public MainViewModel(ApplyThemeSettingsUseCase applyThemeSettingsUseCase,
                          GetBottomNavLabelVisibilityUseCase getBottomNavLabelVisibilityUseCase,
                          GetDefaultTabPreferenceUseCase getDefaultTabPreferenceUseCase,
                          ApplyLanguageSettingsUseCase applyLanguageSettingsUseCase,
@@ -56,7 +52,6 @@ public class MainViewModel extends ViewModel {
                          IsAppInstalledUseCase isAppInstalledUseCase,
                          BuildShortcutIntentUseCase buildShortcutIntentUseCase,
                          GetAppUpdateManagerUseCase getAppUpdateManagerUseCase) {
-        this.application = application;
         this.applyThemeSettingsUseCase = applyThemeSettingsUseCase;
         this.getBottomNavLabelVisibilityUseCase = getBottomNavLabelVisibilityUseCase;
         this.getDefaultTabPreferenceUseCase = getDefaultTabPreferenceUseCase;
@@ -84,26 +79,17 @@ public class MainViewModel extends ViewModel {
      * Loads and applies settings such as theme, bottom nav visibility, default tab, etc.
      * This can be called from onCreate() or similar lifecycle methods in MainActivity.
      */
-    public void applySettings() {
-        boolean changedTheme = applyThemeSettingsUseCase.invoke(
-                application.getResources().getStringArray(R.array.preference_theme_values)
-        );
+    public void applySettings(String[] themeValues,
+                              String[] bottomNavBarLabelsValues,
+                              String[] defaultTabValues) {
+        boolean changedTheme = applyThemeSettingsUseCase.invoke(themeValues);
         themeChanged.setValue(changedTheme);
 
-        String labelKey = application.getString(R.string.key_bottom_navigation_bar_labels);
-        String labelDefaultValue = application.getString(R.string.default_value_bottom_navigation_bar_labels);
-        String[] bottomNavBarLabelsValues =
-                application.getResources().getStringArray(R.array.preference_bottom_navigation_bar_labels_values);
-
-        String labelVisibilityStr = getBottomNavLabelVisibilityUseCase.invoke(labelKey, labelDefaultValue);
+        String labelVisibilityStr = getBottomNavLabelVisibilityUseCase.invoke();
         int visibilityMode = getVisibilityMode(labelVisibilityStr, bottomNavBarLabelsValues);
         bottomNavLabelVisibility.setValue(visibilityMode);
 
-        String defaultTabKey = application.getString(R.string.key_default_tab);
-        String defaultTabValue = application.getString(R.string.default_value_tab);
-        String[] defaultTabValues = application.getResources().getStringArray(R.array.preference_default_tab_values);
-
-        String startFragmentIdValue = getDefaultTabPreferenceUseCase.invoke(defaultTabKey, defaultTabValue);
+        String startFragmentIdValue = getDefaultTabPreferenceUseCase.invoke();
         int startFragmentId;
         if (startFragmentIdValue.equals(defaultTabValues[0])) {
             startFragmentId = R.id.navigation_home;
@@ -136,8 +122,7 @@ public class MainViewModel extends ViewModel {
      * Check if the “Android Tutorials” app is installed or not.
      */
     public boolean isAndroidTutorialsInstalled() {
-        PackageManager pm = application.getPackageManager();
-        return isAppInstalledUseCase.invoke(pm, "com.d4rk.androidtutorials.java");
+        return isAppInstalledUseCase.invoke("com.d4rk.androidtutorials.java");
     }
 
     /**


### PR DESCRIPTION
## Summary
- Remove `Application` dependency and resource lookups from `MainViewModel`
- Shift package checks and preference key lookups to `DefaultMainRepository`
- Pass required string arrays from `MainActivity` when applying settings

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b42f4e8388832dac82d7e07d74fca2