### PR TITLE
Fix up navigation parents

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -63,59 +63,59 @@
         <activity
             android:name=".ui.screens.android.CodeActivity"
             android:exported="false"
-            android:parentActivityName=".ui.screens.android.CodeActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
 
         <activity
             android:name=".ui.screens.android.lessons.buttons.radio.RadioButtonsActivity"
             android:exported="false"
             android:label="@string/radio_buttons"
-            android:parentActivityName=".ui.screens.android.lessons.buttons.radio.RadioButtonsActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
 
         <activity
             android:name=".ui.screens.android.lessons.alerts.toast.ToastActivity"
             android:exported="false"
             android:label="@string/toast"
-            android:parentActivityName=".ui.screens.android.lessons.alerts.toast.ToastActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.buttons.image.ImageButtonsActivity"
             android:exported="false"
             android:label="@string/image_buttons"
-            android:parentActivityName=".ui.screens.android.lessons.buttons.image.ImageButtonsActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.views.images.ImagesActivity"
             android:exported="false"
             android:label="@string/image_view"
-            android:parentActivityName=".ui.screens.android.lessons.views.images.ImagesActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.views.images.ImagesCodeActivity"
             android:exported="false"
             android:label="@string/image_view"
-            android:parentActivityName=".ui.screens.android.lessons.views.images.ImagesCodeActivity" />
+            android:parentActivityName=".ui.screens.android.lessons.views.images.ImagesActivity" />
         <activity
             android:name=".ui.screens.android.lessons.alerts.snackbar.SnackBarActivity"
             android:exported="false"
             android:label="@string/snack_bar"
-            android:parentActivityName=".ui.screens.android.lessons.alerts.snackbar.SnackBarActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.clocks.clock.ClockCodeActivity"
             android:exported="false"
             android:label="@string/clocks"
-            android:parentActivityName=".ui.screens.android.lessons.clocks.clock.ClockCodeActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.clocks.clock.ClockActivity"
             android:exported="false"
             android:label="@string/clocks"
-            android:parentActivityName=".ui.screens.android.lessons.clocks.clock.ClockActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.clocks.timepicker.TimePickerActivity"
             android:exported="false"
             android:label="@string/timepicker"
-            android:parentActivityName=".ui.screens.android.lessons.clocks.timepicker.TimePickerActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.views.web.WebViewActivity"
             android:exported="false"
             android:label="@string/web_view"
-            android:parentActivityName=".ui.screens.android.lessons.views.web.WebViewActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity-alias
             android:name="com.d4rk.androidtutorials.java.ui.android.webviews.WebViewActivity"
             android:exported="false"
@@ -124,190 +124,190 @@
             android:name=".ui.screens.android.lessons.progress.progressbar.ProgressBarActivity"
             android:exported="false"
             android:label="@string/progress_bar"
-            android:parentActivityName=".ui.screens.android.lessons.progress.progressbar.ProgressBarActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.progress.progressbar.ProgressBarCodeActivity"
             android:exported="false"
             android:label="@string/progress_bar"
-            android:parentActivityName=".ui.screens.android.lessons.progress.progressbar.ProgressBarCodeActivity" />
+            android:parentActivityName=".ui.screens.android.lessons.progress.progressbar.ProgressBarActivity" />
         <activity
             android:name=".ui.screens.android.lessons.notifications.simple.SimpleNotificationActivity"
             android:exported="false"
             android:label="@string/simple_notifications"
-            android:parentActivityName=".ui.screens.android.lessons.notifications.simple.SimpleNotificationActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.notifications.inbox.InboxNotificationActivity"
             android:exported="false"
             android:label="@string/inbox_notifications"
-            android:parentActivityName=".ui.screens.android.lessons.notifications.inbox.InboxNotificationActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.textboxes.passwordbox.PasswordBoxActivity"
             android:exported="false"
             android:label="@string/password_box"
-            android:parentActivityName=".ui.screens.android.lessons.textboxes.passwordbox.PasswordBoxActivity"
+            android:parentActivityName=".ui.screens.main.MainActivity"
             android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".ui.screens.android.lessons.clocks.datepicker.DatePickerActivity"
             android:exported="false"
             android:label="@string/datepicker"
-            android:parentActivityName=".ui.screens.android.lessons.clocks.datepicker.DatePickerActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.textboxes.textbox.TextboxActivity"
             android:exported="false"
             android:label="@string/textbox"
-            android:parentActivityName=".ui.screens.android.lessons.textboxes.textbox.TextboxActivity"
+            android:parentActivityName=".ui.screens.main.MainActivity"
             android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".ui.screens.android.lessons.alerts.alertdialog.AlertDialogActivity"
             android:exported="false"
             android:label="@string/alert_dialog"
-            android:parentActivityName=".ui.screens.android.lessons.alerts.alertdialog.AlertDialogActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.settings.screens.permissions.PermissionsActivity"
             android:exported="false"
             android:label="@string/permissions"
-            android:parentActivityName=".ui.screens.settings.screens.permissions.PermissionsActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.basics.shortcuts.ShortcutsActivity"
             android:exported="false"
             android:label="@string/shortcuts"
-            android:parentActivityName=".ui.screens.android.lessons.basics.shortcuts.ShortcutsActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.basics.shortcuts.tabs.CodeShortcutsActivity"
             android:exported="false"
             android:label="@string/writing_code"
-            android:parentActivityName=".ui.screens.android.lessons.basics.shortcuts.tabs.CodeShortcutsActivity" />
+            android:parentActivityName=".ui.screens.android.lessons.basics.shortcuts.ShortcutsActivity" />
         <activity
             android:name=".ui.screens.android.lessons.basics.shortcuts.tabs.GeneralShortcutsActivity"
             android:exported="false"
             android:label="@string/general"
-            android:parentActivityName=".ui.screens.android.lessons.basics.shortcuts.tabs.GeneralShortcutsActivity" />
+            android:parentActivityName=".ui.screens.android.lessons.basics.shortcuts.ShortcutsActivity" />
         <activity
             android:name=".ui.screens.android.lessons.basics.shortcuts.tabs.RefactoringShortcutsActivity"
             android:exported="false"
             android:label="@string/refactoring"
-            android:parentActivityName=".ui.screens.android.lessons.basics.shortcuts.tabs.RefactoringShortcutsActivity" />
+            android:parentActivityName=".ui.screens.android.lessons.basics.shortcuts.ShortcutsActivity" />
         <activity
             android:name=".ui.screens.android.lessons.basics.shortcuts.tabs.BuildShortcutsActivity"
             android:exported="false"
             android:label="@string/build_and_run"
-            android:parentActivityName=".ui.screens.android.lessons.basics.shortcuts.tabs.BuildShortcutsActivity" />
+            android:parentActivityName=".ui.screens.android.lessons.basics.shortcuts.ShortcutsActivity" />
         <activity
             android:name=".ui.screens.android.lessons.clocks.chronometer.ChronometerActivity"
             android:exported="false"
             android:label="@string/chronometer"
-            android:parentActivityName=".ui.screens.android.lessons.clocks.chronometer.ChronometerActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.basics.shortcuts.tabs.DebuggingShortcutsActivity"
             android:exported="false"
             android:label="@string/debugging"
-            android:parentActivityName=".ui.screens.android.lessons.basics.shortcuts.tabs.DebuggingShortcutsActivity" />
+            android:parentActivityName=".ui.screens.android.lessons.basics.shortcuts.ShortcutsActivity" />
         <activity
             android:name=".ui.screens.android.lessons.basics.shortcuts.tabs.NavigationAndSearchingShortcutsActivity"
             android:exported="false"
             android:label="@string/navigation_and_searching"
-            android:parentActivityName=".ui.screens.android.lessons.basics.shortcuts.tabs.NavigationAndSearchingShortcutsActivity" />
+            android:parentActivityName=".ui.screens.android.lessons.basics.shortcuts.ShortcutsActivity" />
         <activity
             android:name=".ui.screens.android.lessons.basics.shortcuts.tabs.VersionControlShortcutsActivity"
             android:exported="false"
             android:label="@string/version_control"
-            android:parentActivityName=".ui.screens.android.lessons.basics.shortcuts.tabs.VersionControlShortcutsActivity" />
+            android:parentActivityName=".ui.screens.android.lessons.basics.shortcuts.ShortcutsActivity" />
         <activity
             android:name=".ui.screens.android.lessons.basics.history.AndroidHistory"
             android:exported="false"
             android:label="@string/history_of_android"
-            android:parentActivityName=".ui.screens.android.lessons.basics.history.AndroidHistory" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.buttons.buttons.ButtonsCodeActivity"
             android:exported="false"
             android:label="@string/buttons"
-            android:parentActivityName=".ui.screens.android.lessons.buttons.buttons.ButtonsCodeActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.layouts.linear.LinearLayoutActivity"
             android:exported="false"
             android:label="@string/linear_layout"
-            android:parentActivityName=".ui.screens.android.lessons.layouts.linear.LinearLayoutActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.layouts.linear.LinearLayoutCodeActivity"
             android:exported="false"
             android:label="@string/linear_layout"
-            android:parentActivityName=".ui.screens.android.lessons.layouts.linear.LinearLayoutCodeActivity" />
+            android:parentActivityName=".ui.screens.android.lessons.layouts.linear.LinearLayoutActivity" />
         <activity
             android:name=".ui.screens.android.lessons.layouts.relative.RelativeLayoutActivity"
             android:exported="false"
             android:label="@string/relative_layout"
-            android:parentActivityName=".ui.screens.android.lessons.layouts.relative.RelativeLayoutActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.layouts.relative.RelativeLayoutCodeActivity"
             android:exported="false"
             android:label="@string/relative_layout"
-            android:parentActivityName=".ui.screens.android.lessons.layouts.relative.RelativeLayoutCodeActivity" />
+            android:parentActivityName=".ui.screens.android.lessons.layouts.relative.RelativeLayoutActivity" />
         <activity
             android:name=".ui.screens.android.lessons.layouts.table.TableLayoutActivity"
             android:exported="false"
             android:label="@string/table_layout"
-            android:parentActivityName=".ui.screens.android.lessons.layouts.table.TableLayoutActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.layouts.table.TableLayoutCodeActivity"
             android:exported="false"
             android:label="@string/table_layout"
-            android:parentActivityName=".ui.screens.android.lessons.layouts.table.TableLayoutCodeActivity" />
+            android:parentActivityName=".ui.screens.android.lessons.layouts.table.TableLayoutActivity" />
         <activity
             android:name=".ui.screens.android.lessons.views.grid.GirdViewActivity"
             android:exported="false"
             android:label="@string/grid_view"
-            android:parentActivityName=".ui.screens.android.lessons.views.grid.GirdViewActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.help.HelpActivity"
             android:exported="false"
             android:label="@string/help"
-            android:parentActivityName=".ui.screens.help.HelpActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.buttons.switches.SwitchActivity"
             android:exported="false"
             android:label="@string/switches"
-            android:parentActivityName=".ui.screens.android.lessons.buttons.switches.SwitchActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.buttons.buttons.ButtonsActivity"
             android:exported="false"
             android:label="@string/buttons"
-            android:parentActivityName=".ui.screens.android.lessons.buttons.buttons.ButtonsActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.start.AndroidStartProjectActivity"
             android:exported="false"
             android:label="@string/android_start"
             android:theme="@style/AppTheme"
-            android:parentActivityName=".ui.screens.android.lessons.start.AndroidStartProjectActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.basics.sdk.AndroidSDK"
             android:exported="false"
             android:label="@string/android_sdk"
-            android:parentActivityName=".ui.screens.android.lessons.basics.sdk.AndroidSDK" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.basics.viewbinding.ViewBindingTutorialActivity"
             android:exported="false"
             android:label="@string/view_binding"
-            android:parentActivityName=".ui.screens.android.lessons.basics.viewbinding.ViewBindingTutorialActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.basics.permissions.PermissionsTutorialActivity"
             android:exported="false"
             android:label="@string/permissions"
-            android:parentActivityName=".ui.screens.android.lessons.basics.permissions.PermissionsTutorialActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.reviews.ratingbar.RatingBarActivity"
             android:exported="false"
             android:label="@string/rating_bar"
-            android:parentActivityName=".ui.screens.android.lessons.reviews.ratingbar.RatingBarActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.navigation.bottomnavigation.BottomNavigationActivity"
             android:exported="false"
             android:label="@string/bottom_navigation"
-            android:parentActivityName=".ui.screens.android.lessons.navigation.bottomnavigation.BottomNavigationActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
         <activity
             android:name=".ui.screens.android.lessons.navigation.drawer.NavigationDrawerActivity"
             android:exported="false"
             android:label="@string/navigation_drawer"
-            android:parentActivityName=".ui.screens.android.lessons.navigation.drawer.NavigationDrawerActivity" />
+            android:parentActivityName=".ui.screens.main.MainActivity" />
 
         <receiver
             android:name=".notifications.receivers.QuizReminderReceiver"

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/navigation/UpNavigationActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/navigation/UpNavigationActivity.java
@@ -1,0 +1,25 @@
+package com.d4rk.androidtutorials.java.ui.components.navigation;
+
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.NavUtils;
+
+public abstract class UpNavigationActivity extends AppCompatActivity {
+    @Override
+    protected void onPostCreate(@Nullable Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        NavUtils.navigateUpFromSameTask(this);
+        return true;
+    }
+}

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/CodeActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/CodeActivity.java
@@ -3,7 +3,7 @@ package com.d4rk.androidtutorials.java.ui.screens.android;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
@@ -17,7 +17,7 @@ import com.d4rk.androidtutorials.java.ui.screens.android.tabs.NoCodeFragment;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 import com.google.android.material.tabs.TabLayoutMediator;
 
-public class CodeActivity extends AppCompatActivity {
+public class CodeActivity extends UpNavigationActivity {
     private ActivityTabLayoutBinding binding;
 
     @Override
@@ -63,7 +63,7 @@ public class CodeActivity extends AppCompatActivity {
     private static class CodePagerAdapter extends FragmentStateAdapter {
         private final LessonRepository.Lesson lesson;
 
-        public CodePagerAdapter(@NonNull AppCompatActivity fragmentActivity, LessonRepository.Lesson lesson) {
+        public CodePagerAdapter(@NonNull UpNavigationActivity fragmentActivity, LessonRepository.Lesson lesson) {
             super(fragmentActivity);
             this.lesson = lesson;
         }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/alerts/alertdialog/AlertDialogActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/alerts/alertdialog/AlertDialogActivity.java
@@ -4,7 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivityAlertDialogBinding;
@@ -12,7 +12,7 @@ import com.d4rk.androidtutorials.java.ui.screens.android.CodeActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
-public class AlertDialogActivity extends AppCompatActivity {
+public class AlertDialogActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivityAlertDialogBinding binding;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/alerts/snackbar/SnackBarActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/alerts/snackbar/SnackBarActivity.java
@@ -4,7 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivitySnackBarBinding;
@@ -12,7 +12,7 @@ import com.d4rk.androidtutorials.java.ui.screens.android.CodeActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 import com.google.android.material.snackbar.Snackbar;
 
-public class SnackBarActivity extends AppCompatActivity {
+public class SnackBarActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivitySnackBarBinding binding;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/alerts/toast/ToastActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/alerts/toast/ToastActivity.java
@@ -5,14 +5,14 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.widget.Toast;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivityToastBinding;
 import com.d4rk.androidtutorials.java.ui.screens.android.CodeActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 
-public class ToastActivity extends AppCompatActivity {
+public class ToastActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivityToastBinding binding;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/history/AndroidHistory.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/history/AndroidHistory.java
@@ -2,7 +2,7 @@ package com.d4rk.androidtutorials.java.ui.screens.android.lessons.basics.history
 
 import android.os.Bundle;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityAndroidHistoryBinding;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
@@ -11,7 +11,7 @@ import com.google.android.gms.ads.MobileAds;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class AndroidHistory extends AppCompatActivity {
+public class AndroidHistory extends UpNavigationActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/permissions/PermissionsTutorialActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/permissions/PermissionsTutorialActivity.java
@@ -4,7 +4,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityPermissionsTutorialBinding;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
@@ -13,7 +13,7 @@ import com.google.android.gms.ads.MobileAds;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class PermissionsTutorialActivity extends AppCompatActivity {
+public class PermissionsTutorialActivity extends UpNavigationActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/sdk/AndroidSDK.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/sdk/AndroidSDK.java
@@ -7,7 +7,7 @@ import android.widget.TableLayout;
 import android.widget.TableRow;
 import android.widget.TextView;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.data.model.AndroidVersion;
@@ -21,7 +21,7 @@ import java.util.List;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class AndroidSDK extends AppCompatActivity {
+public class AndroidSDK extends UpNavigationActivity {
     private ActivityAndroidSdkBinding binding;
     private final List<AndroidVersion> androidVersions = Arrays.asList(
             new AndroidVersion("1.0", "1", "BASE", "None", "2008"),

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/ShortcutsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/ShortcutsActivity.java
@@ -5,7 +5,7 @@ import android.net.Uri;
 import android.os.Bundle;
 
 import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import androidx.preference.PreferenceFragmentCompat;
 
 import com.d4rk.androidtutorials.java.R;
@@ -14,7 +14,7 @@ import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.MobileAds;
 
-public class ShortcutsActivity extends AppCompatActivity {
+public class ShortcutsActivity extends UpNavigationActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/BuildShortcutsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/BuildShortcutsActivity.java
@@ -2,7 +2,7 @@ package com.d4rk.androidtutorials.java.ui.screens.android.lessons.basics.shortcu
 
 import android.os.Bundle;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityShortcutsBuildBinding;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
@@ -11,7 +11,7 @@ import com.google.android.gms.ads.MobileAds;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class BuildShortcutsActivity extends AppCompatActivity {
+public class BuildShortcutsActivity extends UpNavigationActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/CodeShortcutsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/CodeShortcutsActivity.java
@@ -2,7 +2,7 @@ package com.d4rk.androidtutorials.java.ui.screens.android.lessons.basics.shortcu
 
 import android.os.Bundle;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityShortcutsCodeBinding;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
@@ -11,7 +11,7 @@ import com.google.android.gms.ads.MobileAds;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class CodeShortcutsActivity extends AppCompatActivity {
+public class CodeShortcutsActivity extends UpNavigationActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/DebuggingShortcutsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/DebuggingShortcutsActivity.java
@@ -2,7 +2,7 @@ package com.d4rk.androidtutorials.java.ui.screens.android.lessons.basics.shortcu
 
 import android.os.Bundle;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityShortcutsDebuggingBinding;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
@@ -11,7 +11,7 @@ import com.google.android.gms.ads.MobileAds;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class DebuggingShortcutsActivity extends AppCompatActivity {
+public class DebuggingShortcutsActivity extends UpNavigationActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/GeneralShortcutsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/GeneralShortcutsActivity.java
@@ -2,7 +2,7 @@ package com.d4rk.androidtutorials.java.ui.screens.android.lessons.basics.shortcu
 
 import android.os.Bundle;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityShortcutsGeneralBinding;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
@@ -11,7 +11,7 @@ import com.google.android.gms.ads.MobileAds;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class GeneralShortcutsActivity extends AppCompatActivity {
+public class GeneralShortcutsActivity extends UpNavigationActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/NavigationAndSearchingShortcutsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/NavigationAndSearchingShortcutsActivity.java
@@ -2,7 +2,7 @@ package com.d4rk.androidtutorials.java.ui.screens.android.lessons.basics.shortcu
 
 import android.os.Bundle;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityShortcutsNavigationAndSearchingBinding;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
@@ -11,7 +11,7 @@ import com.google.android.gms.ads.MobileAds;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class NavigationAndSearchingShortcutsActivity extends AppCompatActivity {
+public class NavigationAndSearchingShortcutsActivity extends UpNavigationActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/RefactoringShortcutsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/RefactoringShortcutsActivity.java
@@ -2,7 +2,7 @@ package com.d4rk.androidtutorials.java.ui.screens.android.lessons.basics.shortcu
 
 import android.os.Bundle;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityShortcutsRefractoringBinding;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
@@ -11,7 +11,7 @@ import com.google.android.gms.ads.MobileAds;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class RefactoringShortcutsActivity extends AppCompatActivity {
+public class RefactoringShortcutsActivity extends UpNavigationActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/VersionControlShortcutsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/VersionControlShortcutsActivity.java
@@ -2,7 +2,7 @@ package com.d4rk.androidtutorials.java.ui.screens.android.lessons.basics.shortcu
 
 import android.os.Bundle;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityShortcutsVersionControlBinding;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
@@ -11,7 +11,7 @@ import com.google.android.gms.ads.MobileAds;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class VersionControlShortcutsActivity extends AppCompatActivity {
+public class VersionControlShortcutsActivity extends UpNavigationActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/viewbinding/ViewBindingTutorialActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/viewbinding/ViewBindingTutorialActivity.java
@@ -6,7 +6,7 @@ import android.graphics.Typeface;
 import android.net.Uri;
 import android.os.Bundle;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import androidx.preference.PreferenceManager;
 
 import com.d4rk.androidtutorials.java.R;
@@ -25,7 +25,7 @@ import java.io.InputStreamReader;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class ViewBindingTutorialActivity extends AppCompatActivity {
+public class ViewBindingTutorialActivity extends UpNavigationActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/ButtonsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/ButtonsActivity.java
@@ -4,7 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivityButtonsBinding;
@@ -13,7 +13,7 @@ import com.google.android.material.snackbar.Snackbar;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class ButtonsActivity extends AppCompatActivity {
+public class ButtonsActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivityButtonsBinding binding;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/ButtonsCodeActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/ButtonsCodeActivity.java
@@ -4,7 +4,7 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import androidx.fragment.app.Fragment;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 
@@ -17,7 +17,7 @@ import com.google.android.material.tabs.TabLayoutMediator;
 
 import java.util.ArrayList;
 
-public class ButtonsCodeActivity extends AppCompatActivity {
+public class ButtonsCodeActivity extends UpNavigationActivity {
     private ActivityTabLayoutBinding binding;
 
     @Override
@@ -51,7 +51,7 @@ public class ButtonsCodeActivity extends AppCompatActivity {
         private final ArrayList<Fragment> fragmentList = new ArrayList<>();
         private final ArrayList<String> fragmentTitleList = new ArrayList<>();
 
-        public ViewPagerAdapter(@NonNull AppCompatActivity activity) {
+        public ViewPagerAdapter(@NonNull UpNavigationActivity activity) {
             super(activity);
         }
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/image/ImageButtonsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/image/ImageButtonsActivity.java
@@ -4,7 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivityImageButtonsBinding;
@@ -12,7 +12,7 @@ import com.d4rk.androidtutorials.java.ui.screens.android.CodeActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 import com.google.android.material.snackbar.Snackbar;
 
-public class ImageButtonsActivity extends AppCompatActivity {
+public class ImageButtonsActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivityImageButtonsBinding binding;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/radio/RadioButtonsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/radio/RadioButtonsActivity.java
@@ -5,14 +5,14 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.widget.RadioButton;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityRadioButtonsBinding;
 import com.d4rk.androidtutorials.java.ui.screens.android.CodeActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 import com.google.android.material.snackbar.Snackbar;
 
-public class RadioButtonsActivity extends AppCompatActivity {
+public class RadioButtonsActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivityRadioButtonsBinding binding;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/switches/SwitchActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/switches/SwitchActivity.java
@@ -4,7 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivitySwitchBinding;
@@ -14,7 +14,7 @@ import com.google.android.material.snackbar.Snackbar;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class SwitchActivity extends AppCompatActivity {
+public class SwitchActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivitySwitchBinding binding;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/chronometer/ChronometerActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/chronometer/ChronometerActivity.java
@@ -6,13 +6,13 @@ import android.os.Handler;
 import android.os.SystemClock;
 
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityChronometerBinding;
 import com.d4rk.androidtutorials.java.ui.screens.android.CodeActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 
-public class ChronometerActivity extends AppCompatActivity {
+public class ChronometerActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivityChronometerBinding binding;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/clock/ClockActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/clock/ClockActivity.java
@@ -4,14 +4,14 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityClockBinding;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class ClockActivity extends AppCompatActivity {
+public class ClockActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivityClockBinding binding;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/clock/ClockCodeActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/clock/ClockCodeActivity.java
@@ -4,7 +4,7 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import androidx.fragment.app.Fragment;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 
@@ -17,7 +17,7 @@ import com.google.android.material.tabs.TabLayoutMediator;
 
 import java.util.ArrayList;
 
-public class ClockCodeActivity extends AppCompatActivity {
+public class ClockCodeActivity extends UpNavigationActivity {
     private ActivityTabLayoutBinding binding;
 
     @Override
@@ -51,7 +51,7 @@ public class ClockCodeActivity extends AppCompatActivity {
         private final ArrayList<Fragment> fragmentList = new ArrayList<>();
         private final ArrayList<String> fragmentTitleList = new ArrayList<>();
 
-        public ViewPagerAdapter(@NonNull AppCompatActivity activity) {
+        public ViewPagerAdapter(@NonNull UpNavigationActivity activity) {
             super(activity);
         }
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/datepicker/DatePickerActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/datepicker/DatePickerActivity.java
@@ -5,7 +5,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityDatePickerBinding;
 import com.d4rk.androidtutorials.java.ui.screens.android.CodeActivity;
@@ -15,7 +15,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Locale;
 
-public class DatePickerActivity extends AppCompatActivity {
+public class DatePickerActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private final Calendar calendar = Calendar.getInstance();
     private final SimpleDateFormat dateFormat = new SimpleDateFormat("dd/MM/yyyy", Locale.getDefault());

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/timepicker/TimePickerActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/timepicker/TimePickerActivity.java
@@ -5,7 +5,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityTimePickerBinding;
 import com.d4rk.androidtutorials.java.ui.screens.android.CodeActivity;
@@ -15,7 +15,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Locale;
 
-public class TimePickerActivity extends AppCompatActivity {
+public class TimePickerActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private final Calendar calendar = Calendar.getInstance();
     private ActivityTimePickerBinding binding;

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/linear/LinearLayoutActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/linear/LinearLayoutActivity.java
@@ -4,14 +4,14 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityLinearLayoutBinding;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class LinearLayoutActivity extends AppCompatActivity {
+public class LinearLayoutActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivityLinearLayoutBinding binding;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/linear/LinearLayoutCodeActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/linear/LinearLayoutCodeActivity.java
@@ -4,7 +4,7 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import androidx.fragment.app.Fragment;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 import androidx.viewpager2.widget.ViewPager2;
@@ -19,7 +19,7 @@ import com.google.android.material.tabs.TabLayoutMediator;
 import java.util.ArrayList;
 import java.util.List;
 
-public class LinearLayoutCodeActivity extends AppCompatActivity {
+public class LinearLayoutCodeActivity extends UpNavigationActivity {
     private ViewPager2 viewPager2;
 
     @Override
@@ -55,7 +55,7 @@ public class LinearLayoutCodeActivity extends AppCompatActivity {
         private final List<Fragment> fragmentList = new ArrayList<>();
         private final List<String> fragmentTitleList = new ArrayList<>();
 
-        public ViewPagerAdapter(@NonNull AppCompatActivity activity) {
+        public ViewPagerAdapter(@NonNull UpNavigationActivity activity) {
             super(activity);
         }
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/relative/RelativeLayoutActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/relative/RelativeLayoutActivity.java
@@ -4,14 +4,14 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityRelativeLayoutBinding;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class RelativeLayoutActivity extends AppCompatActivity {
+public class RelativeLayoutActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivityRelativeLayoutBinding binding;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/relative/RelativeLayoutCodeActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/relative/RelativeLayoutCodeActivity.java
@@ -4,7 +4,7 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import androidx.fragment.app.Fragment;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 
@@ -17,7 +17,7 @@ import com.google.android.material.tabs.TabLayoutMediator;
 
 import java.util.ArrayList;
 
-public class RelativeLayoutCodeActivity extends AppCompatActivity {
+public class RelativeLayoutCodeActivity extends UpNavigationActivity {
     private ActivityTabLayoutBinding binding;
 
     @Override
@@ -51,7 +51,7 @@ public class RelativeLayoutCodeActivity extends AppCompatActivity {
         private final ArrayList<Fragment> fragmentList = new ArrayList<>();
         private final ArrayList<String> fragmentTitleList = new ArrayList<>();
 
-        public ViewPagerAdapter(@NonNull AppCompatActivity activity) {
+        public ViewPagerAdapter(@NonNull UpNavigationActivity activity) {
             super(activity);
         }
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/table/TableLayoutActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/table/TableLayoutActivity.java
@@ -4,14 +4,14 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityTableLayoutBinding;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class TableLayoutActivity extends AppCompatActivity {
+public class TableLayoutActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivityTableLayoutBinding binding;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/table/TableLayoutCodeActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/table/TableLayoutCodeActivity.java
@@ -4,7 +4,7 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import androidx.fragment.app.Fragment;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 
@@ -17,7 +17,7 @@ import com.google.android.material.tabs.TabLayoutMediator;
 
 import java.util.ArrayList;
 
-public class TableLayoutCodeActivity extends AppCompatActivity {
+public class TableLayoutCodeActivity extends UpNavigationActivity {
     private ActivityTabLayoutBinding binding;
 
     @Override
@@ -51,7 +51,7 @@ public class TableLayoutCodeActivity extends AppCompatActivity {
         private final ArrayList<Fragment> fragmentList = new ArrayList<>();
         private final ArrayList<String> fragmentTitleList = new ArrayList<>();
 
-        public ViewPagerAdapter(@NonNull AppCompatActivity activity) {
+        public ViewPagerAdapter(@NonNull UpNavigationActivity activity) {
             super(activity);
         }
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/navigation/bottomnavigation/BottomNavigationActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/navigation/bottomnavigation/BottomNavigationActivity.java
@@ -4,14 +4,14 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import com.d4rk.androidtutorials.java.R;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityBottomNavigationBinding;
 import com.d4rk.androidtutorials.java.ui.screens.android.CodeActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 
-public class BottomNavigationActivity extends AppCompatActivity {
+public class BottomNavigationActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivityBottomNavigationBinding binding;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/navigation/drawer/NavigationDrawerActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/navigation/drawer/NavigationDrawerActivity.java
@@ -4,7 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import androidx.core.view.GravityCompat;
 
 import com.d4rk.androidtutorials.java.R;
@@ -12,7 +12,7 @@ import com.d4rk.androidtutorials.java.databinding.ActivityNavigationDrawerBindin
 import com.d4rk.androidtutorials.java.ui.screens.android.CodeActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 
-public class NavigationDrawerActivity extends AppCompatActivity {
+public class NavigationDrawerActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivityNavigationDrawerBinding binding;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/notifications/inbox/InboxNotificationActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/notifications/inbox/InboxNotificationActivity.java
@@ -10,14 +10,14 @@ import android.os.Bundle;
 import android.os.Handler;
 
 import androidx.annotation.RequiresApi;
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import androidx.core.app.NotificationCompat;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivityNotificationBinding;
 import com.d4rk.androidtutorials.java.ui.screens.android.CodeActivity;
 
-public class InboxNotificationActivity extends AppCompatActivity {
+public class InboxNotificationActivity extends UpNavigationActivity {
     private final String notificationChannelId = "inbox_notification";
     private final int notificationId = 1;
     private final Handler handler = new Handler();

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/notifications/simple/SimpleNotificationActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/notifications/simple/SimpleNotificationActivity.java
@@ -10,14 +10,14 @@ import android.os.Bundle;
 import android.os.Handler;
 
 import androidx.annotation.RequiresApi;
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import androidx.core.app.NotificationCompat;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivityNotificationBinding;
 import com.d4rk.androidtutorials.java.ui.screens.android.CodeActivity;
 
-public class SimpleNotificationActivity extends AppCompatActivity {
+public class SimpleNotificationActivity extends UpNavigationActivity {
     private final String simpleChannelId = "simple_notification";
     private final int simpleNotificationId = 1;
     private final Handler handler = new Handler();

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/progress/progressbar/ProgressBarActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/progress/progressbar/ProgressBarActivity.java
@@ -4,14 +4,14 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityProgressBarBinding;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class ProgressBarActivity extends AppCompatActivity {
+public class ProgressBarActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivityProgressBarBinding binding;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/progress/progressbar/ProgressBarCodeActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/progress/progressbar/ProgressBarCodeActivity.java
@@ -4,7 +4,7 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import androidx.fragment.app.Fragment;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 
@@ -17,7 +17,7 @@ import com.google.android.material.tabs.TabLayoutMediator;
 
 import java.util.ArrayList;
 
-public class ProgressBarCodeActivity extends AppCompatActivity {
+public class ProgressBarCodeActivity extends UpNavigationActivity {
     private ActivityTabLayoutBinding binding;
 
     @Override
@@ -51,7 +51,7 @@ public class ProgressBarCodeActivity extends AppCompatActivity {
         private final ArrayList<Fragment> fragmentList = new ArrayList<>();
         private final ArrayList<String> fragmentTitleList = new ArrayList<>();
 
-        public ViewPagerAdapter(@NonNull AppCompatActivity activity) {
+        public ViewPagerAdapter(@NonNull UpNavigationActivity activity) {
             super(activity);
         }
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/reviews/ratingbar/RatingBarActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/reviews/ratingbar/RatingBarActivity.java
@@ -5,13 +5,13 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.widget.Toast;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivityRatingBarBinding;
 import com.d4rk.androidtutorials.java.ui.screens.android.CodeActivity;
 
-public class RatingBarActivity extends AppCompatActivity {
+public class RatingBarActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivityRatingBarBinding binding;
     private float rating = 0f;

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/start/AndroidStartProjectActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/start/AndroidStartProjectActivity.java
@@ -4,7 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.text.method.LinkMovementMethod;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.BuildConfig;
 import com.d4rk.androidtutorials.java.R;
@@ -15,7 +15,7 @@ import com.google.android.gms.ads.MobileAds;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class AndroidStartProjectActivity extends AppCompatActivity {
+public class AndroidStartProjectActivity extends UpNavigationActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/textboxes/passwordbox/PasswordBoxActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/textboxes/passwordbox/PasswordBoxActivity.java
@@ -7,14 +7,14 @@ import android.os.Handler;
 import android.text.method.HideReturnsTransformationMethod;
 import android.text.method.PasswordTransformationMethod;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivityPasswordBoxBinding;
 import com.d4rk.androidtutorials.java.ui.screens.android.CodeActivity;
 import com.google.android.material.snackbar.Snackbar;
 
-public class PasswordBoxActivity extends AppCompatActivity {
+public class PasswordBoxActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivityPasswordBoxBinding binding;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/textboxes/textbox/TextboxActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/textboxes/textbox/TextboxActivity.java
@@ -4,13 +4,13 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityTextBoxBinding;
 import com.d4rk.androidtutorials.java.ui.screens.android.CodeActivity;
 import com.google.android.material.snackbar.Snackbar;
 
-public class TextboxActivity extends AppCompatActivity {
+public class TextboxActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivityTextBoxBinding binding;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/grid/GirdViewActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/grid/GirdViewActivity.java
@@ -7,13 +7,13 @@ import android.widget.ArrayAdapter;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityGridViewBinding;
 import com.d4rk.androidtutorials.java.ui.screens.android.CodeActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 
-public class GirdViewActivity extends AppCompatActivity {
+public class GirdViewActivity extends UpNavigationActivity {
 
     private final String[] numbers = {"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"};
     private final Handler handler = new Handler();

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/images/ImagesActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/images/ImagesActivity.java
@@ -4,14 +4,14 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityImagesBinding;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class ImagesActivity extends AppCompatActivity {
+public class ImagesActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivityImagesBinding binding;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/images/ImagesCodeActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/images/ImagesCodeActivity.java
@@ -4,7 +4,7 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import androidx.fragment.app.Fragment;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 
@@ -17,7 +17,7 @@ import com.google.android.material.tabs.TabLayoutMediator;
 
 import java.util.ArrayList;
 
-public class ImagesCodeActivity extends AppCompatActivity {
+public class ImagesCodeActivity extends UpNavigationActivity {
     private ActivityTabLayoutBinding binding;
 
     @Override
@@ -51,7 +51,7 @@ public class ImagesCodeActivity extends AppCompatActivity {
         private final ArrayList<Fragment> fragmentList = new ArrayList<>();
         private final ArrayList<String> fragmentTitleList = new ArrayList<>();
 
-        public ViewPagerAdapter(@NonNull AppCompatActivity activity) {
+        public ViewPagerAdapter(@NonNull UpNavigationActivity activity) {
             super(activity);
         }
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/web/WebViewActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/web/WebViewActivity.java
@@ -7,7 +7,7 @@ import android.os.Handler;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityWebviewBinding;
 import com.d4rk.androidtutorials.java.ui.screens.android.CodeActivity;
@@ -15,7 +15,7 @@ import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class WebViewActivity extends AppCompatActivity {
+public class WebViewActivity extends UpNavigationActivity {
     private final Handler handler = new Handler();
     private ActivityWebviewBinding binding;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/help/HelpActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/help/HelpActivity.java
@@ -11,7 +11,7 @@ import android.view.MenuItem;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
@@ -30,7 +30,7 @@ import com.mikepenz.aboutlibraries.LibsBuilder;
 import dagger.hilt.android.AndroidEntryPoint;
 
 @AndroidEntryPoint
-public class HelpActivity extends AppCompatActivity {
+public class HelpActivity extends UpNavigationActivity {
 
     private HelpViewModel helpViewModel;
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/settings/screens/permissions/PermissionsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/settings/screens/permissions/PermissionsActivity.java
@@ -2,14 +2,14 @@ package com.d4rk.androidtutorials.java.ui.screens.settings.screens.permissions;
 
 import android.os.Bundle;
 
-import androidx.appcompat.app.AppCompatActivity;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import androidx.preference.PreferenceFragmentCompat;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivityPermissionsBinding;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 
-public class PermissionsActivity extends AppCompatActivity {
+public class PermissionsActivity extends UpNavigationActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);


### PR DESCRIPTION
## Summary
- Correct parentActivityName declarations in manifest to reference MainActivity or specific hosts
- Add UpNavigationActivity base class to handle the action bar Up button using NavUtils
- Convert activities to extend UpNavigationActivity for consistent in-app navigation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4655d020c832da0f81bababd2f7c7