### PR TITLE
Bypass startup screen and handle consent in MainActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,11 +36,6 @@
         tools:targetApi="33">
 
         <activity
-            android:name=".ui.screens.startup.StartupActivity"
-            android:noHistory="true"
-            android:theme="@style/AppTheme" />
-
-        <activity
             android:name=".ui.screens.main.MainActivity"
             android:exported="true"
             android:theme="@style/SplashScreenTheme">

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/startup/StartupActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/startup/StartupActivity.java
@@ -1,65 +1,25 @@
 package com.d4rk.androidtutorials.java.ui.screens.startup;
 
-import android.Manifest;
 import android.content.Intent;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.lifecycle.ViewModelProvider;
 
-import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivityStartupBinding;
 import com.d4rk.androidtutorials.java.ui.screens.main.MainActivity;
-import com.d4rk.androidtutorials.java.ui.screens.startup.dialogs.ConsentDialogFragment;
-import com.google.android.ump.ConsentInformation;
-import com.google.android.ump.ConsentRequestParameters;
-import com.google.android.ump.UserMessagingPlatform;
-import com.d4rk.androidtutorials.java.utils.ConsentUtils;
-
-
-import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
 import dagger.hilt.android.AndroidEntryPoint;
+import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
 @AndroidEntryPoint
 public class StartupActivity extends AppCompatActivity {
 
-    private StartupViewModel startupViewModel;
-    private ConsentInformation consentInformation;
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        com.d4rk.androidtutorials.java.databinding.ActivityStartupBinding binding = ActivityStartupBinding.inflate(getLayoutInflater());
+        ActivityStartupBinding binding = ActivityStartupBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
-
-        ConsentUtils.applyStoredConsent(this);
-
-        startupViewModel = new ViewModelProvider(this).get(StartupViewModel.class);
-
-        consentInformation = UserMessagingPlatform.getConsentInformation(this);
-        ConsentRequestParameters params = new ConsentRequestParameters.Builder()
-                .setTagForUnderAgeOfConsent(false)
-                .build();
-
-        startupViewModel.requestConsentInfoUpdate(
-                this,
-                params,
-                () -> {
-                    if (consentInformation.isConsentFormAvailable()) {
-                        startupViewModel.loadConsentForm(
-                                this,
-                                formError -> ConsentUtils.updateFirebaseConsent(this,
-                                        false, false, false, false)
-                        );
-                    } else if (consentInformation.getConsentStatus() == ConsentInformation.ConsentStatus.OBTAINED) {
-                        ConsentUtils.applyStoredConsent(this);
-                    }
-                },
-                formError -> {}
-        );
 
         new FastScrollerBuilder(binding.scrollView)
                 .useMd2Style()
@@ -71,23 +31,8 @@ public class StartupActivity extends AppCompatActivity {
         );
 
         binding.floatingButtonAgree.setOnClickListener(v -> {
-            ConsentDialogFragment dialog = new ConsentDialogFragment();
-            dialog.setConsentListener((analytics, adStorage, adUserData, adPersonalization) -> {
-                ConsentUtils.updateFirebaseConsent(this,
-                        analytics, adStorage, adUserData, adPersonalization);
-                proceedToMainActivity();
-            });
-            dialog.show(getSupportFragmentManager(), "consent_dialog");
+            startActivity(new Intent(this, MainActivity.class));
+            finish();
         });
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS}, 1);
-        }
     }
-
-    private void proceedToMainActivity() {
-        startActivity(new Intent(this, MainActivity.class));
-        finish();
-    }
-
 }


### PR DESCRIPTION
## Summary
- remove StartupActivity from manifest so app launches directly into MainActivity
- move consent flow into MainActivity with dialog and notification permission request
- simplify StartupActivity to a lightweight redirect screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b46a126874832da5e05d26feef76cf