### PR TITLE
Remove Google Play Instant Apps integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Improved lesson UI with a top app bar and share action in the Start a New Project tutorial.
 - Added translations for the Start a New Project lesson across supported languages.
+- Removed Google Play Instant Apps integration ahead of its deprecation in December 2025.
 
 # Version 5.0.2:
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,6 @@ dependencies {
     // Google
     implementation libs.material
     implementation libs.play.services.ads
-    implementation libs.play.services.instantapps
     implementation libs.review
     implementation libs.app.update
     implementation libs.volley

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/navigation/BottomSheetMenuFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/navigation/BottomSheetMenuFragment.java
@@ -14,7 +14,6 @@ import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.BottomSheetMenuBinding;
 import com.d4rk.androidtutorials.java.ui.screens.settings.SettingsActivity;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
-import com.google.android.gms.instantapps.InstantApps;
 
 public class BottomSheetMenuFragment extends BottomSheetDialogFragment {
 
@@ -57,16 +56,8 @@ public class BottomSheetMenuFragment extends BottomSheetDialogFragment {
             Intent sharingIntent = new Intent(Intent.ACTION_SEND);
             sharingIntent.setType("text/plain");
 
-            String shareLink;
-            boolean isInstant = InstantApps
-                    .getPackageManagerCompat(requireContext())
-                    .isInstantApp();
-            if (isInstant) {
-                shareLink = "https://example.com/instant";
-            } else {
-                shareLink = "https://play.google.com/store/apps/details?id="
-                        + BuildConfig.APPLICATION_ID;
-            }
+            String shareLink = "https://play.google.com/store/apps/details?id="
+                    + BuildConfig.APPLICATION_ID;
 
             String shareMessage = getString(R.string.share_message, shareLink);
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,6 @@ coreKtx = "1.17.0"
 material = "1.14.0-alpha04"
 multidex = "2.0.1"
 playServicesAds = "24.5.0"
-playServicesInstantApps = "18.2.0"
 codeview = "1.3.9"
 hilt = "2.57.1"
 
@@ -63,7 +62,6 @@ materialratingbar-library = { module = "me.zhanghai.android.materialratingbar:li
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore" }
 mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInline" }
 play-services-ads = { module = "com.google.android.gms:play-services-ads", version.ref = "playServicesAds" }
-play-services-instantapps = { module = "com.google.android.gms:play-services-instantapps", version.ref = "playServicesInstantApps" }
 review = { module = "com.google.android.play:review", version.ref = "review" }
 volley = { module = "com.android.volley:volley", version.ref = "volley" }
 codeview = { module = "io.github.amrdeveloper:codeview", version.ref = "codeview" }


### PR DESCRIPTION
## Summary
- Drop Google Play Instant Apps dependency and related code
- Always share the Play Store link in the bottom sheet menu
- Note Instant Apps removal in changelog

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b48b334768832d8fb06b40d32d2205