### PR TITLE
feat: add emphasized text styles with material shape overlays

### DIFF
--- a/app/src/main/res/layout/activity_alert_dialog.xml
+++ b/app/src/main/res/layout/activity_alert_dialog.xml
@@ -11,10 +11,12 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/show_dialog"
+        android:textAppearance="@style/TextAppearance.BodyLargeEmphasized"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:shapeAppearanceOverlay="@style/ShapeTokens.Clover" />
 
     <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
         android:id="@+id/floating_button_show_syntax"

--- a/app/src/main/res/layout/activity_android_start_project.xml
+++ b/app/src/main/res/layout/activity_android_start_project.xml
@@ -13,6 +13,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:menu="@menu/menu_share"
+        app:shapeAppearanceOverlay="@style/ShapeTokens.Clover"
         app:title="@string/android_start_project" />
 
     <me.zhanghai.android.fastscroll.FastScrollScrollView
@@ -30,11 +31,11 @@
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/text_view_first_step"
-                style="@style/TextAppearance.Material3.HeadlineLarge"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_margin="24dp"
                 android:text="@string/step1"
+                android:textAppearance="@style/TextAppearance.TitleLargeEmphasized"
                 android:textColor="?attr/colorSecondary"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -45,6 +46,7 @@
                 android:layout_height="wrap_content"
                 android:layout_margin="24dp"
                 android:text="@string/summary_first_step"
+                android:textAppearance="@style/TextAppearance.BodyLargeEmphasized"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/text_view_first_step" />
 
@@ -54,10 +56,10 @@
                 android:layout_width="match_parent"
                 android:layout_height="256dp"
                 android:layout_margin="24dp"
-                app:cardCornerRadius="24dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/text_view_first_step_summary">
+                app:layout_constraintTop_toBottomOf="@id/text_view_first_step_summary"
+                app:shapeAppearanceOverlay="@style/ShapeTokens.Clover">
 
                 <androidx.appcompat.widget.AppCompatImageView
                     android:layout_width="match_parent"
@@ -77,11 +79,11 @@
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/text_view_second_step"
-                style="@style/TextAppearance.Material3.HeadlineLarge"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_margin="24dp"
                 android:text="@string/step2"
+                android:textAppearance="@style/TextAppearance.TitleLargeEmphasized"
                 android:textColor="?attr/colorSecondary"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/ad_view" />
@@ -92,6 +94,7 @@
                 android:layout_height="wrap_content"
                 android:layout_margin="24dp"
                 android:text="@string/summary_second_step"
+                android:textAppearance="@style/TextAppearance.BodyLargeEmphasized"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/text_view_second_step" />
 
@@ -101,10 +104,10 @@
                 android:layout_width="match_parent"
                 android:layout_height="256dp"
                 android:layout_margin="24dp"
-                app:cardCornerRadius="24dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/text_view_second_step_summary">
+                app:layout_constraintTop_toBottomOf="@id/text_view_second_step_summary"
+                app:shapeAppearanceOverlay="@style/ShapeTokens.Clover">
 
                 <androidx.appcompat.widget.AppCompatImageView
                     android:layout_width="match_parent"
@@ -115,11 +118,11 @@
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/text_view_third_step"
-                style="@style/TextAppearance.Material3.HeadlineLarge"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_margin="24dp"
                 android:text="@string/step3"
+                android:textAppearance="@style/TextAppearance.TitleLargeEmphasized"
                 android:textColor="?attr/colorSecondary"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/card_view_second_step" />
@@ -130,6 +133,7 @@
                 android:layout_height="wrap_content"
                 android:layout_margin="24dp"
                 android:text="@string/summary_third_step"
+                android:textAppearance="@style/TextAppearance.BodyLargeEmphasized"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/text_view_third_step" />
 
@@ -139,10 +143,10 @@
                 android:layout_width="match_parent"
                 android:layout_height="256dp"
                 android:layout_margin="24dp"
-                app:cardCornerRadius="24dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/text_view_third_step_summary">
+                app:layout_constraintTop_toBottomOf="@id/text_view_third_step_summary"
+                app:shapeAppearanceOverlay="@style/ShapeTokens.Clover">
 
                 <androidx.appcompat.widget.AppCompatImageView
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -15,6 +15,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:navigationIcon="@drawable/ic_menu"
+            app:shapeAppearanceOverlay="@style/ShapeTokens.Clover"
             app:title="@string/app_name" />
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/app/src/main/res/values/shape_tokens.xml
+++ b/app/src/main/res/values/shape_tokens.xml
@@ -1,5 +1,8 @@
 <resources>
-    <style name="ShapeTokens.Clover">
+    <!-- Base style required for Material 3 shape tokens -->
+    <style name="ShapeTokens" />
+
+    <style name="ShapeTokens.Clover" parent="ShapeTokens">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSizeTopLeft">24dp</item>
         <item name="cornerSizeTopRight">24dp</item>

--- a/app/src/main/res/values/shape_tokens.xml
+++ b/app/src/main/res/values/shape_tokens.xml
@@ -1,0 +1,9 @@
+<resources>
+    <style name="ShapeTokens.Clover">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSizeTopLeft">24dp</item>
+        <item name="cornerSizeTopRight">24dp</item>
+        <item name="cornerSizeBottomLeft">8dp</item>
+        <item name="cornerSizeBottomRight">8dp</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -28,6 +28,35 @@
         <item name="dialogCornerRadius">28dp</item>
         <item name="alertDialogTheme">@style/ThemeOverlay.Material3.MaterialAlertDialog</item>
         <item name="switchPreferenceCompatStyle">@style/switchPreferenceCompatStyle</item>
+        <!-- Apply emphasized text appearances -->
+        <item name="textAppearanceTitleLarge">@style/TextAppearance.TitleLargeEmphasized</item>
+        <item name="textAppearanceBodyLarge">@style/TextAppearance.BodyLargeEmphasized</item>
+        <!-- Map custom widget styles using Material 3 shape tokens -->
+        <item name="toolbarStyle">@style/Widget.App.Toolbar.Clover</item>
+        <item name="materialCardViewStyle">@style/Widget.App.CardView.Clover</item>
+        <item name="materialButtonStyle">@style/Widget.App.Button.Clover</item>
+    </style>
+
+    <!-- Emphasized text appearances -->
+    <style name="TextAppearance.TitleLargeEmphasized" parent="TextAppearance.Material3.TitleLarge">
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="TextAppearance.BodyLargeEmphasized" parent="TextAppearance.Material3.BodyLarge">
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <!-- Widget styles using Material 3 shape tokens -->
+    <style name="Widget.App.Toolbar.Clover" parent="@style/Widget.Material3.Toolbar">
+        <item name="shapeAppearanceOverlay">@style/ShapeTokens.Clover</item>
+    </style>
+
+    <style name="Widget.App.CardView.Clover" parent="@style/Widget.Material3.CardView">
+        <item name="shapeAppearanceOverlay">@style/ShapeTokens.Clover</item>
+    </style>
+
+    <style name="Widget.App.Button.Clover" parent="@style/Widget.Material3.Button">
+        <item name="shapeAppearance">@style/ShapeTokens.Clover</item>
     </style>
 
     <style name="ShapeAppearanceOverlay.CardView" parent="">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -51,7 +51,7 @@
         <item name="shapeAppearanceOverlay">@style/ShapeTokens.Clover</item>
     </style>
 
-    <style name="Widget.App.CardView.Clover" parent="@style/Widget.Material3.CardView">
+    <style name="Widget.App.CardView.Clover" parent="@style/Widget.Material3.CardView.Outlined">
         <item name="shapeAppearanceOverlay">@style/ShapeTokens.Clover</item>
     </style>
 


### PR DESCRIPTION
## Summary
- define bold TitleLarge and BodyLarge text appearances and apply via theme
- map Material 3 Clover shape tokens to toolbars, cards, and buttons
- apply emphasized text and shape overlays in key layouts

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b48d033be0832d8b2d394afdeec924