### PR TITLE
Add content description for app icon

### DIFF
--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -34,10 +34,10 @@
                     android:focusable="true"
                     android:src="@mipmap/ic_launcher"
                     android:tooltipText="@string/tooltip_open_me"
+                    android:contentDescription="@string/app_name"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    tools:ignore="SpeakableTextPresentCheck" />
+                    app:layout_constraintTop_toTopOf="parent" />
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/text_view_app_title"


### PR DESCRIPTION
## Summary
- improve accessibility by adding a content description to the app icon in the About fragment

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c00c70f0832dad9f7cb1928f89e2