### PR TITLE
Add content descriptions for start project screenshots

### DIFF
--- a/app/src/main/res/layout/activity_android_start_project.xml
+++ b/app/src/main/res/layout/activity_android_start_project.xml
@@ -65,7 +65,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="fitXY"
-                    android:src="@drawable/im_step1" />
+                    android:src="@drawable/im_step1"
+                    android:contentDescription="@string/im_step1_desc" />
             </com.google.android.material.card.MaterialCardView>
 
             <com.google.android.gms.ads.AdView
@@ -113,7 +114,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="fitXY"
-                    android:src="@drawable/im_step2" />
+                    android:src="@drawable/im_step2"
+                    android:contentDescription="@string/im_step2_desc" />
             </com.google.android.material.card.MaterialCardView>
 
             <com.google.android.material.textview.MaterialTextView
@@ -152,7 +154,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="fitXY"
-                    android:src="@drawable/im_step3" />
+                    android:src="@drawable/im_step3"
+                    android:contentDescription="@string/im_step3_desc" />
             </com.google.android.material.card.MaterialCardView>
 
             <com.airbnb.lottie.LottieAnimationView

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -445,4 +445,7 @@
     <string name="quiz_reminder_title">تذكير الاختبار اليومي</string>
     <string name="quiz_reminder_body">عد للاختبار اليومي اليوم!</string>
     <string name="other_apps_title">تطبيقات أخرى من المطور</string>
+    <string name="im_step1_desc">لقطة شاشة تعرض زر مشروع جديد في Android Studio.</string>
+    <string name="im_step2_desc">لقطة شاشة تعرض اختيار نوع النشاط أثناء إعداد المشروع.</string>
+    <string name="im_step3_desc">لقطة شاشة تعرض حقول اسم التطبيق والحزمة واللغة وSDK الأدنى.</string>
 </resources>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -445,4 +445,7 @@
     <string name="quiz_reminder_title">Ежедневно напомняне за тест</string>
     <string name="quiz_reminder_body">Върнете се за днешния тест!</string>
     <string name="other_apps_title">Още приложения от разработчика</string>
+    <string name="im_step1_desc">Екранна снимка, показваща бутона Нов проект в Android Studio.</string>
+    <string name="im_step2_desc">Екранна снимка, показваща избор на тип активност при настройка на проекта.</string>
+    <string name="im_step3_desc">Екранна снимка, показваща полета за име на приложение, пакет, език и минимален SDK.</string>
 </resources>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -445,4 +445,7 @@
     <string name="quiz_reminder_title">দৈনিক কুইজ রিমাইন্ডার</string>
     <string name="quiz_reminder_body">আজকের কুইজে ফিরে আসুন!</string>
     <string name="other_apps_title">ডেভেলপারকে আরো টুল</string>
+    <string name="im_step1_desc">স্ক্রিনশটে Android Studio-তে নতুন প্রকল্প বোতাম দেখা যাচ্ছে।</string>
+    <string name="im_step2_desc">স্ক্রিনশটে প্রকল্প সেটআপের সময় অ্যাক্টিভিটি টাইপ নির্বাচন দেখা যাচ্ছে।</string>
+    <string name="im_step3_desc">স্ক্রিনশটে অ্যাপ নাম, প্যাকেজ, ভাষা ও ন্যূনতম SDK ফিল্ড দেখা যাচ্ছে।</string>
 </resources>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -445,4 +445,7 @@
     <string name="quiz_reminder_title">Tägliche Quiz-Erinnerung</string>
     <string name="quiz_reminder_body">Komm zurück für das heutige Quiz!</string>
     <string name="other_apps_title">Weitere Apps des Entwicklers</string>
+    <string name="im_step1_desc">Screenshot mit der Schaltfläche Neues Projekt in Android Studio.</string>
+    <string name="im_step2_desc">Screenshot mit der Auswahl des Aktivitätstyps während der Projekteinrichtung.</string>
+    <string name="im_step3_desc">Screenshot mit Feldern für App-Name, Paket, Sprache und minimale SDK.</string>
 </resources>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -445,4 +445,7 @@
     <string name="quiz_reminder_title">Recordatorio diario del cuestionario</string>
     <string name="quiz_reminder_body">¡Vuelve para el cuestionario de hoy!</string>
     <string name="other_apps_title">Más aplicaciones por el desarrollador</string>
+    <string name="im_step1_desc">Captura de pantalla que muestra el botón Nuevo proyecto en Android Studio.</string>
+    <string name="im_step2_desc">Captura de pantalla que muestra la selección del tipo de actividad durante la configuración.</string>
+    <string name="im_step3_desc">Captura de pantalla que muestra campos para nombre de la app, paquete, idioma y SDK mínimo.</string>
 </resources>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -445,4 +445,7 @@
     <string name="quiz_reminder_title">Recordatorio diario del cuestionario</string>
     <string name="quiz_reminder_body">¡Vuelve para el cuestionario de hoy!</string>
     <string name="other_apps_title">Más apps del desarrollador</string>
+    <string name="im_step1_desc">Captura de pantalla que muestra el botón Nuevo proyecto en Android Studio.</string>
+    <string name="im_step2_desc">Captura de pantalla que muestra la selección del tipo de actividad durante la configuración.</string>
+    <string name="im_step3_desc">Captura de pantalla que muestra campos para nombre de la app, paquete, idioma y SDK mínimo.</string>
 </resources>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -445,4 +445,7 @@
     <string name="quiz_reminder_title">Paalala sa Araw-araw na Pagsusulit</string>
     <string name="quiz_reminder_body">Bumalik para sa pagsusulit ngayong araw!</string>
     <string name="other_apps_title">Higit pang mga app mula sa developer</string>
+    <string name="im_step1_desc">Screenshot na nagpapakita ng button na New project sa Android Studio.</string>
+    <string name="im_step2_desc">Screenshot na nagpapakita ng pagpili ng uri ng activity sa pag-set up ng proyekto.</string>
+    <string name="im_step3_desc">Screenshot na nagpapakita ng mga field para sa pangalan ng app, package, wika, at minimum SDK.</string>
 </resources>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -445,4 +445,7 @@
     <string name="quiz_reminder_title">Rappel quotidien du quiz</string>
     <string name="quiz_reminder_body">Revenez pour le quiz du jour !</string>
     <string name="other_apps_title">Plus d\'applications par le développeur</string>
+    <string name="im_step1_desc">Capture d’écran montrant le bouton Nouveau projet dans Android Studio.</string>
+    <string name="im_step2_desc">Capture d’écran montrant la sélection du type d’activité pendant la configuration du projet.</string>
+    <string name="im_step3_desc">Capture d’écran montrant les champs nom de l’appli, package, langue et SDK minimal.</string>
 </resources>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -420,4 +420,7 @@
     <string name="quiz_reminder_title">दैनिक प्रश्नोत्तरी अनुस्मारक</string>
     <string name="quiz_reminder_body">आज की प्रश्नोत्तरी के लिए वापस आएं!</string>
     <string name="other_apps_title">डेवलपर द्वारा अधिक एप्लिकेशन</string>
+    <string name="im_step1_desc">स्क्रीनशॉट जिसमें Android Studio में नया प्रोजेक्ट बटन दिख रहा है।</string>
+    <string name="im_step2_desc">स्क्रीनशॉट जिसमें प्रोजेक्ट सेटअप के दौरान एक्टिविटी प्रकार चुनना दिख रहा है।</string>
+    <string name="im_step3_desc">स्क्रीनशॉट जिसमें ऐप नाम, पैकेज, भाषा और न्यूनतम SDK के फ़ील्ड दिख रहे हैं।</string>
 </resources>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -3,4 +3,7 @@
     <string name="get_on_google_play">Szerezd meg a Google Playen</string>
     <string name="learn_more">Tudj meg többet</string>
     <string name="play_store">Play Áruház</string>
+    <string name="im_step1_desc">Képernyőkép az Új projekt gombbal az Android Studioban.</string>
+    <string name="im_step2_desc">Képernyőkép a projekt beállításakor az aktivitástípus választásáról.</string>
+    <string name="im_step3_desc">Képernyőkép az alkalmazás neve, csomagja, nyelve és minimum SDK mezőiről.</string>
 </resources>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -420,4 +420,7 @@
     <string name="quiz_reminder_title">Pengingat Kuis Harian</string>
     <string name="quiz_reminder_body">Kembali untuk kuis hari ini!</string>
     <string name="other_apps_title">Lebih banyak aplikasi oleh pengembang</string>
+    <string name="im_step1_desc">Cuplikan layar yang menampilkan tombol Proyek baru di Android Studio.</string>
+    <string name="im_step2_desc">Cuplikan layar yang menampilkan pemilihan jenis aktivitas saat menyiapkan proyek.</string>
+    <string name="im_step3_desc">Cuplikan layar yang menampilkan kolom nama aplikasi, paket, bahasa, dan SDK minimum.</string>
 </resources>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -3,4 +3,7 @@
     <string name="get_on_google_play">Scaricalo su Google Play</string>
     <string name="learn_more">Scopri di più</string>
     <string name="play_store">Play Store</string>
+    <string name="im_step1_desc">Screenshot che mostra il pulsante Nuovo progetto in Android Studio.</string>
+    <string name="im_step2_desc">Screenshot che mostra la selezione del tipo di attività durante la configurazione del progetto.</string>
+    <string name="im_step3_desc">Screenshot che mostra i campi nome app, pacchetto, lingua e SDK minimo.</string>
 </resources>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -3,4 +3,7 @@
     <string name="get_on_google_play">Google Play で入手しよう</string>
     <string name="learn_more">詳しく見る</string>
     <string name="play_store">Play ストア</string>
+    <string name="im_step1_desc">Android Studio の新規プロジェクトボタンを示すスクリーンショット。</string>
+    <string name="im_step2_desc">プロジェクト設定中のアクティビティタイプ選択を示すスクリーンショット。</string>
+    <string name="im_step3_desc">アプリ名、パッケージ、言語、最小 SDK の入力欄を示すスクリーンショット。</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -445,4 +445,7 @@
     <string name="quiz_reminder_title">일일 퀴즈 알림</string>
     <string name="quiz_reminder_body">오늘의 퀴즈를 위해 다시 오세요!</string>
     <string name="other_apps_title">개발자의 다른 앱</string>
+    <string name="im_step1_desc">Android Studio에서 새 프로젝트 버튼을 보여주는 스크린샷.</string>
+    <string name="im_step2_desc">프로젝트 설정 중 액티비티 유형 선택을 보여주는 스크린샷.</string>
+    <string name="im_step3_desc">앱 이름, 패키지, 언어 및 최소 SDK 필드를 보여주는 스크린샷.</string>
 </resources>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -3,4 +3,7 @@
     <string name="get_on_google_play">Pobierz z Google Play</string>
     <string name="learn_more">Dowiedz się więcej</string>
     <string name="play_store">Sklep Play</string>
+    <string name="im_step1_desc">Zrzut ekranu pokazujący przycisk Nowy projekt w Android Studio.</string>
+    <string name="im_step2_desc">Zrzut ekranu pokazujący wybór typu aktywności podczas konfiguracji projektu.</string>
+    <string name="im_step3_desc">Zrzut ekranu pokazujący pola nazwy aplikacji, pakietu, języka i minimalnego SDK.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -445,4 +445,7 @@
     <string name="quiz_reminder_title">Lembrete diário do quiz</string>
     <string name="quiz_reminder_body">Volte para o quiz de hoje!</string>
     <string name="other_apps_title">Mais aplicativos do desenvolvedor</string>
+    <string name="im_step1_desc">Captura de tela mostrando o botão Novo projeto no Android Studio.</string>
+    <string name="im_step2_desc">Captura de tela mostrando a seleção do tipo de atividade na configuração do projeto.</string>
+    <string name="im_step3_desc">Captura de tela mostrando campos de nome do app, pacote, idioma e SDK mínimo.</string>
 </resources>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -420,4 +420,7 @@
     <string name="quiz_reminder_title">Memento zilnic pentru chestionar</string>
     <string name="quiz_reminder_body">Revino pentru chestionarul de astăzi!</string>
     <string name="other_apps_title">Mai multe aplicații ale dezvoltatorului</string>
+    <string name="im_step1_desc">Captură de ecran cu butonul Proiect nou în Android Studio.</string>
+    <string name="im_step2_desc">Captură de ecran cu selectarea tipului de activitate în timpul configurării proiectului.</string>
+    <string name="im_step3_desc">Captură de ecran cu câmpurile nume aplicație, pachet, limbă și SDK minim.</string>
 </resources>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -420,4 +420,7 @@
     <string name="quiz_reminder_title">Ежедневное напоминание о викторине</string>
     <string name="quiz_reminder_body">Возвращайтесь на сегодняшнюю викторину!</string>
     <string name="other_apps_title">Больше приложений от разработчика</string>
+    <string name="im_step1_desc">Скриншот с кнопкой Новый проект в Android Studio.</string>
+    <string name="im_step2_desc">Скриншот выбора типа активности при настройке проекта.</string>
+    <string name="im_step3_desc">Скриншот полей имени приложения, пакета, языка и минимального SDK.</string>
 </resources>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -445,4 +445,7 @@
     <string name="quiz_reminder_title">Daglig quizpåminnelse</string>
     <string name="quiz_reminder_body">Kom tillbaka för dagens quiz!</string>
     <string name="other_apps_title">Fler appar av utvecklaren</string>
+    <string name="im_step1_desc">Skärmdump som visar knappen Nytt projekt i Android Studio.</string>
+    <string name="im_step2_desc">Skärmdump som visar val av aktivitetstyp vid projektkonfiguration.</string>
+    <string name="im_step3_desc">Skärmdump som visar fälten för appnamn, paket, språk och lägsta SDK.</string>
 </resources>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -445,4 +445,7 @@
     <string name="quiz_reminder_title">การแจ้งเตือนแบบทดสอบรายวัน</string>
     <string name="quiz_reminder_body">กลับมาทำแบบทดสอบของวันนี้!</string>
     <string name="other_apps_title">แอปอื่นๆ จากนักพัฒนา</string>
+    <string name="im_step1_desc">ภาพหน้าจอแสดงปุ่มโปรเจ็กต์ใหม่ใน Android Studio.</string>
+    <string name="im_step2_desc">ภาพหน้าจอแสดงการเลือกประเภทกิจกรรมระหว่างตั้งค่าโปรเจ็กต์.</string>
+    <string name="im_step3_desc">ภาพหน้าจอแสดงช่องชื่อแอป แพ็กเกจ ภาษา และ SDK ขั้นต่ำ.</string>
 </resources>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -445,4 +445,7 @@
     <string name="quiz_reminder_title">Günlük Test Hatırlatıcısı</string>
     <string name="quiz_reminder_body">Bugünün testi için geri gelin!</string>
     <string name="other_apps_title">Geliştiricinin diğer uygulamaları</string>
+    <string name="im_step1_desc">Android Studio’da Yeni proje düğmesini gösteren ekran görüntüsü.</string>
+    <string name="im_step2_desc">Proje kurulumunda etkinlik türü seçimini gösteren ekran görüntüsü.</string>
+    <string name="im_step3_desc">Uygulama adı, paket, dil ve minimum SDK alanlarını gösteren ekran görüntüsü.</string>
 </resources>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -445,4 +445,7 @@
     <string name="quiz_reminder_title">Щоденне нагадування про вікторину</string>
     <string name="quiz_reminder_body">Поверніться на сьогоднішню вікторину!</string>
     <string name="other_apps_title">Інші додатки розробника</string>
+    <string name="im_step1_desc">Знімок екрана з кнопкою Новий проєкт у Android Studio.</string>
+    <string name="im_step2_desc">Знімок екрана вибору типу активності під час налаштування проєкту.</string>
+    <string name="im_step3_desc">Знімок екрана полів назви застосунку, пакета, мови та мінімального SDK.</string>
 </resources>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -445,4 +445,7 @@
     <string name="quiz_reminder_title">روزانہ کوئز یاددہانی</string>
     <string name="quiz_reminder_body">آج کے کوئز کے لیے دوبارہ آئیں!</string>
     <string name="other_apps_title">ڈیولپر کی مزید ایپس</string>
+    <string name="im_step1_desc">اسکرین شاٹ جس میں اینڈروئیڈ اسٹوڈیو میں نیا پروجیکٹ بٹن دکھایا گیا ہے۔</string>
+    <string name="im_step2_desc">اسکرین شاٹ جس میں پروجیکٹ سیٹ اپ کے دوران سرگرمی کی قسم کا انتخاب دکھایا گیا ہے۔</string>
+    <string name="im_step3_desc">اسکرین شاٹ جس میں ایپ کا نام، پیکج، زبان اور کم سے کم SDK کے فیلڈ دکھائے گئے ہیں۔</string>
 </resources>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -445,4 +445,7 @@
     <string name="quiz_reminder_title">Nhắc nhở làm quiz hằng ngày</string>
     <string name="quiz_reminder_body">Quay lại để làm quiz hôm nay!</string>
     <string name="other_apps_title">Các ứng dụng khác của nhà phát triển</string>
+    <string name="im_step1_desc">Ảnh chụp màn hình hiển thị nút Dự án mới trong Android Studio.</string>
+    <string name="im_step2_desc">Ảnh chụp màn hình hiển thị lựa chọn loại hoạt động khi thiết lập dự án.</string>
+    <string name="im_step3_desc">Ảnh chụp màn hình hiển thị các trường tên ứng dụng, gói, ngôn ngữ và SDK tối thiểu.</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -446,4 +446,7 @@
     <string name="quiz_reminder_title">每日測驗提醒</string>
     <string name="quiz_reminder_body">回來參加今天的測驗吧！</string>
     <string name="other_apps_title">開發人員的其他應用程式</string>
+    <string name="im_step1_desc">顯示 Android Studio 中新專案按鈕的螢幕截圖。</string>
+    <string name="im_step2_desc">顯示在專案設定期間選擇活動類型的螢幕截圖。</string>
+    <string name="im_step3_desc">顯示應用名稱、套件、語言和最低 SDK 欄位的螢幕截圖。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -445,4 +445,7 @@
     <string name="quiz_reminder_title">Daily Quiz Reminder</string>
     <string name="quiz_reminder_body">Come back for today\s quiz!</string>
     <string name="other_apps_title">More apps by the developer</string>
+    <string name="im_step1_desc">Screenshot showing the New project button in Android Studio.</string>
+    <string name="im_step2_desc">Screenshot showing activity type selection during project setup.</string>
+    <string name="im_step3_desc">Screenshot showing fields for app name, package, language, and minimum SDK.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add content descriptions for start project tutorial screenshots
- provide localized strings for screenshot descriptions in all language resource files

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c00490d8832db3bcc5701969dc25