### PR TITLE
feat: clarify code snippet tooltip

### DIFF
--- a/app/src/main/res/layout/activity_alert_dialog.xml
+++ b/app/src/main/res/layout/activity_alert_dialog.xml
@@ -24,9 +24,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_bottom_navigation.xml
+++ b/app/src/main/res/layout/activity_bottom_navigation.xml
@@ -29,9 +29,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_buttons.xml
+++ b/app/src/main/res/layout/activity_buttons.xml
@@ -382,10 +382,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_chronometer.xml
+++ b/app/src/main/res/layout/activity_chronometer.xml
@@ -92,10 +92,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_clock.xml
+++ b/app/src/main/res/layout/activity_clock.xml
@@ -97,10 +97,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_date_picker.xml
+++ b/app/src/main/res/layout/activity_date_picker.xml
@@ -46,10 +46,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_grid_view.xml
+++ b/app/src/main/res/layout/activity_grid_view.xml
@@ -22,10 +22,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_image_buttons.xml
+++ b/app/src/main/res/layout/activity_image_buttons.xml
@@ -63,10 +63,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_images.xml
+++ b/app/src/main/res/layout/activity_images.xml
@@ -71,10 +71,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_linear_layout.xml
+++ b/app/src/main/res/layout/activity_linear_layout.xml
@@ -127,10 +127,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_navigation_drawer.xml
+++ b/app/src/main/res/layout/activity_navigation_drawer.xml
@@ -27,9 +27,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="24dp"
-            android:contentDescription="@string/tooltip_show_code"
+            android:contentDescription="@string/tooltip_show_java_code"
             android:text="@string/show_code"
-            android:tooltipText="@string/tooltip_show_code"
+            android:tooltipText="@string/tooltip_show_java_code"
             app:icon="@drawable/ic_code"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_notification.xml
+++ b/app/src/main/res/layout/activity_notification.xml
@@ -21,10 +21,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_password_box.xml
+++ b/app/src/main/res/layout/activity_password_box.xml
@@ -56,10 +56,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_progress_bar.xml
+++ b/app/src/main/res/layout/activity_progress_bar.xml
@@ -104,10 +104,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_radio_buttons.xml
+++ b/app/src/main/res/layout/activity_radio_buttons.xml
@@ -56,10 +56,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_rating_bar.xml
+++ b/app/src/main/res/layout/activity_rating_bar.xml
@@ -43,10 +43,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_relative_layout.xml
+++ b/app/src/main/res/layout/activity_relative_layout.xml
@@ -73,10 +73,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_snack_bar.xml
+++ b/app/src/main/res/layout/activity_snack_bar.xml
@@ -22,10 +22,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_switch.xml
+++ b/app/src/main/res/layout/activity_switch.xml
@@ -126,10 +126,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_table_layout.xml
+++ b/app/src/main/res/layout/activity_table_layout.xml
@@ -239,10 +239,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_text_box.xml
+++ b/app/src/main/res/layout/activity_text_box.xml
@@ -33,10 +33,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_time_picker.xml
+++ b/app/src/main/res/layout/activity_time_picker.xml
@@ -46,10 +46,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_toast.xml
+++ b/app/src/main/res/layout/activity_toast.xml
@@ -22,10 +22,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_webview.xml
+++ b/app/src/main/res/layout/activity_webview.xml
@@ -28,10 +28,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        android:contentDescription="@string/tooltip_show_code"
+        android:contentDescription="@string/tooltip_show_java_code"
         android:text="@string/show_code"
         android:textSize="14sp"
-        android:tooltipText="@string/tooltip_show_code"
+        android:tooltipText="@string/tooltip_show_java_code"
         app:icon="@drawable/ic_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -445,4 +445,5 @@
     <string name="quiz_reminder_title">تذكير الاختبار اليومي</string>
     <string name="quiz_reminder_body">عد للاختبار اليومي اليوم!</string>
     <string name="other_apps_title">تطبيقات أخرى من المطور</string>
+    <string name="tooltip_show_java_code">عرض مقتطفات رمز Java</string>
 </resources>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -445,4 +445,5 @@
     <string name="quiz_reminder_title">Ежедневно напомняне за тест</string>
     <string name="quiz_reminder_body">Върнете се за днешния тест!</string>
     <string name="other_apps_title">Още приложения от разработчика</string>
+    <string name="tooltip_show_java_code">Показване на фрагмент от код на Java</string>
 </resources>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -445,4 +445,5 @@
     <string name="quiz_reminder_title">দৈনিক কুইজ রিমাইন্ডার</string>
     <string name="quiz_reminder_body">আজকের কুইজে ফিরে আসুন!</string>
     <string name="other_apps_title">ডেভেলপারকে আরো টুল</string>
+    <string name="tooltip_show_java_code">জাভা কোড স্নিপেট দেখান</string>
 </resources>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -445,4 +445,5 @@
     <string name="quiz_reminder_title">Tägliche Quiz-Erinnerung</string>
     <string name="quiz_reminder_body">Komm zurück für das heutige Quiz!</string>
     <string name="other_apps_title">Weitere Apps des Entwicklers</string>
+    <string name="tooltip_show_java_code">Java-Code-Snippet anzeigen</string>
 </resources>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -445,4 +445,5 @@
     <string name="quiz_reminder_title">Recordatorio diario del cuestionario</string>
     <string name="quiz_reminder_body">¡Vuelve para el cuestionario de hoy!</string>
     <string name="other_apps_title">Más aplicaciones por el desarrollador</string>
+    <string name="tooltip_show_java_code">Mostrar fragmento de código Java</string>
 </resources>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -445,4 +445,5 @@
     <string name="quiz_reminder_title">Recordatorio diario del cuestionario</string>
     <string name="quiz_reminder_body">¡Vuelve para el cuestionario de hoy!</string>
     <string name="other_apps_title">Más apps del desarrollador</string>
+    <string name="tooltip_show_java_code">Mostrar fragmento de código Java</string>
 </resources>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -445,4 +445,5 @@
     <string name="quiz_reminder_title">Paalala sa Araw-araw na Pagsusulit</string>
     <string name="quiz_reminder_body">Bumalik para sa pagsusulit ngayong araw!</string>
     <string name="other_apps_title">Higit pang mga app mula sa developer</string>
+    <string name="tooltip_show_java_code">Ipakita ang snippet ng code na Java</string>
 </resources>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -445,4 +445,5 @@
     <string name="quiz_reminder_title">Rappel quotidien du quiz</string>
     <string name="quiz_reminder_body">Revenez pour le quiz du jour !</string>
     <string name="other_apps_title">Plus d\'applications par le développeur</string>
+    <string name="tooltip_show_java_code">Afficher l'extrait de code Java</string>
 </resources>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -420,4 +420,5 @@
     <string name="quiz_reminder_title">दैनिक प्रश्नोत्तरी अनुस्मारक</string>
     <string name="quiz_reminder_body">आज की प्रश्नोत्तरी के लिए वापस आएं!</string>
     <string name="other_apps_title">डेवलपर द्वारा अधिक एप्लिकेशन</string>
+    <string name="tooltip_show_java_code">जावा कोड स्निपेट दिखाएं</string>
 </resources>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -3,4 +3,5 @@
     <string name="get_on_google_play">Szerezd meg a Google Playen</string>
     <string name="learn_more">Tudj meg többet</string>
     <string name="play_store">Play Áruház</string>
+    <string name="tooltip_show_java_code">Mutasd meg a Java kódrészletet</string>
 </resources>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -420,4 +420,5 @@
     <string name="quiz_reminder_title">Pengingat Kuis Harian</string>
     <string name="quiz_reminder_body">Kembali untuk kuis hari ini!</string>
     <string name="other_apps_title">Lebih banyak aplikasi oleh pengembang</string>
+    <string name="tooltip_show_java_code">Tampilkan cuplikan kode Java</string>
 </resources>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -3,4 +3,5 @@
     <string name="get_on_google_play">Scaricalo su Google Play</string>
     <string name="learn_more">Scopri di più</string>
     <string name="play_store">Play Store</string>
+    <string name="tooltip_show_java_code">Mostra snippet di codice Java</string>
 </resources>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -3,4 +3,5 @@
     <string name="get_on_google_play">Google Play で入手しよう</string>
     <string name="learn_more">詳しく見る</string>
     <string name="play_store">Play ストア</string>
+    <string name="tooltip_show_java_code">Javaコードスニペットを表示します</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -445,4 +445,5 @@
     <string name="quiz_reminder_title">일일 퀴즈 알림</string>
     <string name="quiz_reminder_body">오늘의 퀴즈를 위해 다시 오세요!</string>
     <string name="other_apps_title">개발자의 다른 앱</string>
+    <string name="tooltip_show_java_code">자바 코드 스니펫을 보여줍니다</string>
 </resources>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -3,4 +3,5 @@
     <string name="get_on_google_play">Pobierz z Google Play</string>
     <string name="learn_more">Dowiedz się więcej</string>
     <string name="play_store">Sklep Play</string>
+    <string name="tooltip_show_java_code">Pokaż fragment kodu Java</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -445,4 +445,5 @@
     <string name="quiz_reminder_title">Lembrete diário do quiz</string>
     <string name="quiz_reminder_body">Volte para o quiz de hoje!</string>
     <string name="other_apps_title">Mais aplicativos do desenvolvedor</string>
+    <string name="tooltip_show_java_code">Mostrar trecho de código Java</string>
 </resources>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -420,4 +420,5 @@
     <string name="quiz_reminder_title">Memento zilnic pentru chestionar</string>
     <string name="quiz_reminder_body">Revino pentru chestionarul de astăzi!</string>
     <string name="other_apps_title">Mai multe aplicații ale dezvoltatorului</string>
+    <string name="tooltip_show_java_code">Afișați fragmentul de cod Java</string>
 </resources>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -420,4 +420,5 @@
     <string name="quiz_reminder_title">Ежедневное напоминание о викторине</string>
     <string name="quiz_reminder_body">Возвращайтесь на сегодняшнюю викторину!</string>
     <string name="other_apps_title">Больше приложений от разработчика</string>
+    <string name="tooltip_show_java_code">Показать фрагмент кода Java</string>
 </resources>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -445,4 +445,5 @@
     <string name="quiz_reminder_title">Daglig quizpåminnelse</string>
     <string name="quiz_reminder_body">Kom tillbaka för dagens quiz!</string>
     <string name="other_apps_title">Fler appar av utvecklaren</string>
+    <string name="tooltip_show_java_code">Visa Java-kodavsnitt</string>
 </resources>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -445,4 +445,5 @@
     <string name="quiz_reminder_title">การแจ้งเตือนแบบทดสอบรายวัน</string>
     <string name="quiz_reminder_body">กลับมาทำแบบทดสอบของวันนี้!</string>
     <string name="other_apps_title">แอปอื่นๆ จากนักพัฒนา</string>
+    <string name="tooltip_show_java_code">แสดงส่วนของโค้ด Java</string>
 </resources>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -445,4 +445,5 @@
     <string name="quiz_reminder_title">Günlük Test Hatırlatıcısı</string>
     <string name="quiz_reminder_body">Bugünün testi için geri gelin!</string>
     <string name="other_apps_title">Geliştiricinin diğer uygulamaları</string>
+    <string name="tooltip_show_java_code">Java kod parçacığını göster</string>
 </resources>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -445,4 +445,5 @@
     <string name="quiz_reminder_title">Щоденне нагадування про вікторину</string>
     <string name="quiz_reminder_body">Поверніться на сьогоднішню вікторину!</string>
     <string name="other_apps_title">Інші додатки розробника</string>
+    <string name="tooltip_show_java_code">Показати фрагмент коду Java</string>
 </resources>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -445,4 +445,5 @@
     <string name="quiz_reminder_title">روزانہ کوئز یاددہانی</string>
     <string name="quiz_reminder_body">آج کے کوئز کے لیے دوبارہ آئیں!</string>
     <string name="other_apps_title">ڈیولپر کی مزید ایپس</string>
+    <string name="tooltip_show_java_code">جاوا کوڈ کا ٹکڑا دکھائیں</string>
 </resources>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -445,4 +445,5 @@
     <string name="quiz_reminder_title">Nhắc nhở làm quiz hằng ngày</string>
     <string name="quiz_reminder_body">Quay lại để làm quiz hôm nay!</string>
     <string name="other_apps_title">Các ứng dụng khác của nhà phát triển</string>
+    <string name="tooltip_show_java_code">Hiển thị đoạn mã Java</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -446,4 +446,5 @@
     <string name="quiz_reminder_title">每日測驗提醒</string>
     <string name="quiz_reminder_body">回來參加今天的測驗吧！</string>
     <string name="other_apps_title">開發人員的其他應用程式</string>
+    <string name="tooltip_show_java_code">顯示 Java 程式碼片段</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -445,4 +445,5 @@
     <string name="quiz_reminder_title">Daily Quiz Reminder</string>
     <string name="quiz_reminder_body">Come back for today\s quiz!</string>
     <string name="other_apps_title">More apps by the developer</string>
+    <string name="tooltip_show_java_code">Show Java code snippet</string>
 </resources>


### PR DESCRIPTION
## Summary
- clarify show code button tooltip with new string `tooltip_show_java_code`
- add translations for the new tooltip across locales
- use new tooltip for accessibility content descriptions

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c16da964832db12eb803dd1e679d