### PR TITLE
Add search filtering to home screen

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeFragment.java
@@ -7,6 +7,7 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.widget.SearchView;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 
@@ -39,6 +40,19 @@ public class HomeFragment extends Fragment {
                 getString(com.d4rk.androidtutorials.java.R.string.announcement_title),
                 getString(com.d4rk.androidtutorials.java.R.string.announcement_subtitle)
         );
+        binding.searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
+            @Override
+            public boolean onQueryTextSubmit(String query) {
+                homeViewModel.setSearchQuery(query);
+                return true;
+            }
+
+            @Override
+            public boolean onQueryTextChange(String newText) {
+                homeViewModel.setSearchQuery(newText);
+                return true;
+            }
+        });
         LayoutInflater inflater = LayoutInflater.from(requireContext());
         homeViewModel.getUiState().observe(getViewLifecycleOwner(), state -> {
             binding.announcementTitle.setText(state.announcementTitle());

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeViewModel.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeViewModel.java
@@ -29,6 +29,8 @@ public class HomeViewModel extends ViewModel {
     private final GetAppPlayStoreUrlUseCase getAppPlayStoreUrlUseCase;
 
     private final MutableLiveData<HomeUiState> uiState = new MutableLiveData<>();
+    private final MutableLiveData<String> searchQuery = new MutableLiveData<>("");
+    private List<PromotedApp> allPromotedApps = new ArrayList<>();
 
     @Inject
     public HomeViewModel(GetDailyTipUseCase getDailyTipUseCase,
@@ -59,18 +61,8 @@ public class HomeViewModel extends ViewModel {
                     result.add(apps.get((startIndex + i) % apps.size()));
                 }
             }
-            HomeUiState current = uiState.getValue();
-            if (current == null) {
-                current = new HomeUiState("", "", "", result);
-            } else {
-                current = new HomeUiState(
-                        current.announcementTitle(),
-                        current.announcementSubtitle(),
-                        current.dailyTip(),
-                        result
-                );
-            }
-            uiState.postValue(current);
+            allPromotedApps = result;
+            filterPromotedApps();
         });
     }
 
@@ -82,6 +74,34 @@ public class HomeViewModel extends ViewModel {
             current = new HomeUiState(title, subtitle, current.dailyTip(), current.promotedApps());
         }
         uiState.setValue(current);
+    }
+
+    public void setSearchQuery(String query) {
+        searchQuery.setValue(query);
+        filterPromotedApps();
+    }
+
+    private void filterPromotedApps() {
+        String query = searchQuery.getValue();
+        List<PromotedApp> filtered = new ArrayList<>();
+        for (PromotedApp app : allPromotedApps) {
+            if (query == null || query.isEmpty() ||
+                    app.name().toLowerCase().contains(query.toLowerCase())) {
+                filtered.add(app);
+            }
+        }
+        HomeUiState current = uiState.getValue();
+        if (current == null) {
+            current = new HomeUiState("", "", getDailyTipUseCase.invoke(), filtered);
+        } else {
+            current = new HomeUiState(
+                    current.announcementTitle(),
+                    current.announcementSubtitle(),
+                    current.dailyTip(),
+                    filtered
+            );
+        }
+        uiState.postValue(current);
     }
 
     /**

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -168,6 +168,15 @@
                     android:text="@string/other_apps_title"
                     android:textAppearance="@style/TextAppearance.Material3.TitleMedium" />
 
+                <androidx.appcompat.widget.SearchView
+                    android:id="@+id/search_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="8dp"
+                    android:queryHint="@string/search_tutorials_hint"
+                    android:contentDescription="@string/search_tutorials_content_description"
+                    android:iconifiedByDefault="false" />
+
                 <HorizontalScrollView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -19,6 +19,8 @@
     <string name="get_on_google_play">نزّله من على Google Play</string>
     <string name="learn_more">اعرف المزيد</string>
     <string name="play_store">متجر Play</string>
+    <string name="search_tutorials_hint">ابحث عن الدروس</string>
+    <string name="search_tutorials_content_description">ابحث عن الدروس</string>
 
     <string name="android_studio">أندرويد ستوديو</string>
 

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -19,6 +19,8 @@
     <string name="get_on_google_play">Вземете от Google Play</string>
     <string name="learn_more">Научете повече</string>
     <string name="play_store">Play Store</string>
+    <string name="search_tutorials_hint">Търсене на уроци</string>
+    <string name="search_tutorials_content_description">Търсене на уроци</string>
 
     <string name="android_studio">Android Studio</string>
 

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -19,6 +19,8 @@
     <string name="get_on_google_play">গুগল প্লে থেকে পান</string>
     <string name="learn_more">আরও জানুন</string>
     <string name="play_store">প্লে স্টোর</string>
+    <string name="search_tutorials_hint">টিউটোরিয়াল খুঁজুন</string>
+    <string name="search_tutorials_content_description">টিউটোরিয়াল খুঁজুন</string>
 
     <string name="android_studio">অ্যান্ড্রয়েড স্টুডিও</string>
 

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -19,6 +19,8 @@
     <string name="get_on_google_play">Jetzt bei Google Play</string>
     <string name="learn_more">Mehr erfahren</string>
     <string name="play_store">Play Store</string>
+    <string name="search_tutorials_hint">Tutorials suchen</string>
+    <string name="search_tutorials_content_description">Tutorials suchen</string>
 
     <string name="android_studio">Android Studio</string>
 

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -19,6 +19,8 @@
     <string name="get_on_google_play">Consíguelo en Google Play</string>
     <string name="learn_more">Más información</string>
     <string name="play_store">Play Store</string>
+    <string name="search_tutorials_hint">Buscar tutoriales</string>
+    <string name="search_tutorials_content_description">Buscar tutoriales</string>
 
     <string name="android_studio">Android Studio</string>
 

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -19,6 +19,8 @@
     <string name="get_on_google_play">Descárgala en Google Play</string>
     <string name="learn_more">Más información</string>
     <string name="play_store">Play Store</string>
+    <string name="search_tutorials_hint">Buscar tutoriales</string>
+    <string name="search_tutorials_content_description">Buscar tutoriales</string>
 
     <string name="android_studio">Android Studio</string>
 

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -19,6 +19,8 @@
     <string name="get_on_google_play">Kunin ito sa Google Play</string>
     <string name="learn_more">Matuto pa</string>
     <string name="play_store">Play Store</string>
+    <string name="search_tutorials_hint">Maghanap ng mga tutorial</string>
+    <string name="search_tutorials_content_description">Maghanap ng mga tutorial</string>
 
     <string name="android_studio">Android Studio</string>
 

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -384,7 +384,7 @@
     <string name="snack_image_button">Bouton d\'image cliqué !</string>
     <string name="toast_this_is_a_toast">Ceci est un Toast !</string>
     <string name="tooltip_show_code">Afficher la syntaxe du code</string>
-    <string name="tooltip_show_java_code_snippet">Afficher l'extrait de code java</string>
+    <string name="tooltip_show_java_code_snippet">Afficher l\'extrait de code java</string>
     <string name="tooltip_open_me">Ouvrez-moi 🌐</string>
     <string name="hint_type">Saisissez ici…</string>
     <string name="hint_password">Entrez votre mot de passe…</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -19,6 +19,8 @@
     <string name="get_on_google_play">Obtenez-le sur Google Play</string>
     <string name="learn_more">En savoir plus</string>
     <string name="play_store">Play Store</string>
+    <string name="search_tutorials_hint">Rechercher des tutoriels</string>
+    <string name="search_tutorials_content_description">Rechercher des tutoriels</string>
 
     <string name="android_studio">Android Studio</string>
 

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -8,6 +8,8 @@
     <string name="get_on_google_play">इसे Google Play पर प्राप्त करें</string>
     <string name="learn_more">और जानें</string>
     <string name="play_store">प्ले स्टोर</string>
+    <string name="search_tutorials_hint">ट्यूटोरियल खोजें</string>
+    <string name="search_tutorials_content_description">ट्यूटोरियल खोजें</string>
     <string name="update_downloaded">अपडेट डाउनलोड किया गया</string>
     <string name="view_in_google_play">Google Play Store में देखें</string>
     <string name="version_info">संस्करण की जानकारी</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -3,6 +3,8 @@
     <string name="get_on_google_play">Szerezd meg a Google Playen</string>
     <string name="learn_more">Tudj meg többet</string>
     <string name="play_store">Play Áruház</string>
+    <string name="search_tutorials_hint">Oktatóanyagok keresése</string>
+    <string name="search_tutorials_content_description">Oktatóanyagok keresése</string>
     <string name="im_step1_desc">Képernyőkép az Új projekt gombbal az Android Studioban.</string>
     <string name="im_step2_desc">Képernyőkép a projekt beállításakor az aktivitástípus választásáról.</string>
     <string name="im_step3_desc">Képernyőkép az alkalmazás neve, csomagja, nyelve és minimum SDK mezőiről.</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -8,6 +8,8 @@
     <string name="get_on_google_play">Dapatkan di Google Play</string>
     <string name="learn_more">Pelajari lebih lanjut</string>
     <string name="play_store">Play Store</string>
+    <string name="search_tutorials_hint">Cari tutorial</string>
+    <string name="search_tutorials_content_description">Cari tutorial</string>
     <string name="update_downloaded">Pembaruan diunduh</string>
     <string name="view_in_google_play">Lihat di Google Play Store</string>
     <string name="version_info">Info versi</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -3,6 +3,8 @@
     <string name="get_on_google_play">Scaricalo su Google Play</string>
     <string name="learn_more">Scopri di più</string>
     <string name="play_store">Play Store</string>
+    <string name="search_tutorials_hint">Cerca tutorial</string>
+    <string name="search_tutorials_content_description">Cerca tutorial</string>
     <string name="im_step1_desc">Screenshot che mostra il pulsante Nuovo progetto in Android Studio.</string>
     <string name="im_step2_desc">Screenshot che mostra la selezione del tipo di attività durante la configurazione del progetto.</string>
     <string name="im_step3_desc">Screenshot che mostra i campi nome app, pacchetto, lingua e SDK minimo.</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -3,6 +3,8 @@
     <string name="get_on_google_play">Google Play で入手しよう</string>
     <string name="learn_more">詳しく見る</string>
     <string name="play_store">Play ストア</string>
+    <string name="search_tutorials_hint">チュートリアルを検索</string>
+    <string name="search_tutorials_content_description">チュートリアルを検索</string>
     <string name="im_step1_desc">Android Studio の新規プロジェクトボタンを示すスクリーンショット。</string>
     <string name="im_step2_desc">プロジェクト設定中のアクティビティタイプ選択を示すスクリーンショット。</string>
     <string name="im_step3_desc">アプリ名、パッケージ、言語、最小 SDK の入力欄を示すスクリーンショット。</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -19,6 +19,8 @@
     <string name="get_on_google_play">Google Play에서 다운로드</string>
     <string name="learn_more">자세히 알아보기</string>
     <string name="play_store">Play 스토어</string>
+    <string name="search_tutorials_hint">튜토리얼 검색</string>
+    <string name="search_tutorials_content_description">튜토리얼 검색</string>
 
     <string name="android_studio">Android Studio</string>
 

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -3,6 +3,8 @@
     <string name="get_on_google_play">Pobierz z Google Play</string>
     <string name="learn_more">Dowiedz się więcej</string>
     <string name="play_store">Sklep Play</string>
+    <string name="search_tutorials_hint">Wyszukaj samouczki</string>
+    <string name="search_tutorials_content_description">Wyszukaj samouczki</string>
     <string name="im_step1_desc">Zrzut ekranu pokazujący przycisk Nowy projekt w Android Studio.</string>
     <string name="im_step2_desc">Zrzut ekranu pokazujący wybór typu aktywności podczas konfiguracji projektu.</string>
     <string name="im_step3_desc">Zrzut ekranu pokazujący pola nazwy aplikacji, pakietu, języka i minimalnego SDK.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -19,6 +19,8 @@
     <string name="get_on_google_play">Disponível no Google Play</string>
     <string name="learn_more">Saiba mais</string>
     <string name="play_store">Play Store</string>
+    <string name="search_tutorials_hint">Pesquisar tutoriais</string>
+    <string name="search_tutorials_content_description">Pesquisar tutoriais</string>
 
     <string name="android_studio">Android Studio</string>
 

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -8,6 +8,8 @@
     <string name="get_on_google_play">Ia-l de pe Google Play</string>
     <string name="learn_more">Află mai multe</string>
     <string name="play_store">Magazin Play</string>
+    <string name="search_tutorials_hint">Caută tutoriale</string>
+    <string name="search_tutorials_content_description">Caută tutoriale</string>
     <string name="update_downloaded">Actualizare descărcată</string>
     <string name="view_in_google_play">Vezi în Magazinul Google Play</string>
     <string name="version_info">Informații versiune</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -8,6 +8,8 @@
     <string name="get_on_google_play">Получить в Google Play</string>
     <string name="learn_more">Узнать больше</string>
     <string name="play_store">Play Маркет</string>
+    <string name="search_tutorials_hint">Поиск руководств</string>
+    <string name="search_tutorials_content_description">Поиск руководств</string>
     <string name="update_downloaded">Обновление загружено</string>
     <string name="view_in_google_play">Просмотреть в Google Play Store</string>
     <string name="version_info">Информация о версии</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -19,6 +19,8 @@
     <string name="get_on_google_play">Hämta den på Google Play</string>
     <string name="learn_more">Läs mer</string>
     <string name="play_store">Play Butik</string>
+    <string name="search_tutorials_hint">Sök handledningar</string>
+    <string name="search_tutorials_content_description">Sök handledningar</string>
 
     <string name="android_studio">Android Studio</string>
 

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -19,6 +19,8 @@
     <string name="get_on_google_play">ดาวน์โหลดได้ที่ Google Play</string>
     <string name="learn_more">เรียนรู้เพิ่มเติม</string>
     <string name="play_store">Play Store</string>
+    <string name="search_tutorials_hint">ค้นหาบทช่วยสอน</string>
+    <string name="search_tutorials_content_description">ค้นหาบทช่วยสอน</string>
 
     <string name="android_studio">Android Studio</string>
 

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -393,7 +393,7 @@
     <string name="snack_image_button">Resim butonuna tıklandı!</string>
     <string name="toast_this_is_a_toast">Bu bir toast!</string>
     <string name="tooltip_show_code">Kod sözdizimini göster</string>
-    <string name="tooltip_show_java_code_snippet">Java Kodu Snippet'i Göster</string>
+    <string name="tooltip_show_java_code_snippet">Java Kodu Snippet\'i Göster</string>
     <string name="tooltip_open_me">Beni aç 🌐</string>
     <string name="hint_type">Buraya yazın…</string>
     <string name="hint_password">Şifrenizi girin…</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -19,6 +19,8 @@
     <string name="get_on_google_play">Google Play\'den edinin</string>
     <string name="learn_more">Daha fazla bilgi edinin</string>
     <string name="play_store">Play Store</string>
+    <string name="search_tutorials_hint">Eğitimleri ara</string>
+    <string name="search_tutorials_content_description">Eğitimleri ara</string>
 
     <string name="android_studio">Android Studio</string>
 

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -19,6 +19,8 @@
     <string name="get_on_google_play">Завантажте з Google Play</string>
     <string name="learn_more">Дізнайтеся більше</string>
     <string name="play_store">Play Store</string>
+    <string name="search_tutorials_hint">Пошук навчальних посібників</string>
+    <string name="search_tutorials_content_description">Пошук навчальних посібників</string>
 
     <string name="android_studio">Android Studio</string>
 

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -19,6 +19,8 @@
     <string name="get_on_google_play">اسے گوگل پلے سے حاصل کریں</string>
     <string name="learn_more">مزید جانیں</string>
     <string name="play_store">پلے اسٹور</string>
+    <string name="search_tutorials_hint">ٹیوٹوریلز تلاش کریں</string>
+    <string name="search_tutorials_content_description">ٹیوٹوریلز تلاش کریں</string>
 
     <string name="android_studio">اینڈرائیڈ اسٹوڈیو</string>
 

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -19,6 +19,8 @@
     <string name="get_on_google_play">Tải trên Google Play</string>
     <string name="learn_more">Tìm hiểu thêm</string>
     <string name="play_store">Cửa hàng Play</string>
+    <string name="search_tutorials_hint">Tìm kiếm hướng dẫn</string>
+    <string name="search_tutorials_content_description">Tìm kiếm hướng dẫn</string>
 
     <string name="android_studio">Android Studio</string>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -19,6 +19,8 @@
     <string name="get_on_google_play">在 Google Play 上取得</string>
     <string name="learn_more">瞭解更多</string>
     <string name="play_store">Play 商店</string>
+    <string name="search_tutorials_hint">搜尋教學</string>
+    <string name="search_tutorials_content_description">搜尋教學</string>
 
     <string name="android_studio">Android Studio</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,8 @@
       <string name="get_on_google_play">Get it on Google Play</string>
       <string name="learn_more">Learn More</string>
       <string name="play_store">Play Store</string>
+      <string name="search_tutorials_hint">Search tutorials</string>
+      <string name="search_tutorials_content_description">Search tutorials</string>
 
     <string name="android_studio">Android Studio</string>
 


### PR DESCRIPTION
## Summary
- add search bar to home screen to filter tutorials in real time
- filter promoted apps based on query in `HomeViewModel`
- provide accessible content descriptions for search

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c3e82660832d8e56693371e6a0f6