### PR TITLE
Remove search from Home fragment

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeFragment.java
@@ -7,7 +7,6 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.widget.SearchView;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 
@@ -40,19 +39,6 @@ public class HomeFragment extends Fragment {
                 getString(com.d4rk.androidtutorials.java.R.string.announcement_title),
                 getString(com.d4rk.androidtutorials.java.R.string.announcement_subtitle)
         );
-        binding.searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
-            @Override
-            public boolean onQueryTextSubmit(String query) {
-                homeViewModel.setSearchQuery(query);
-                return true;
-            }
-
-            @Override
-            public boolean onQueryTextChange(String newText) {
-                homeViewModel.setSearchQuery(newText);
-                return true;
-            }
-        });
         LayoutInflater inflater = LayoutInflater.from(requireContext());
         homeViewModel.getUiState().observe(getViewLifecycleOwner(), state -> {
             binding.announcementTitle.setText(state.announcementTitle());

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeViewModel.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeViewModel.java
@@ -29,7 +29,6 @@ public class HomeViewModel extends ViewModel {
     private final GetAppPlayStoreUrlUseCase getAppPlayStoreUrlUseCase;
 
     private final MutableLiveData<HomeUiState> uiState = new MutableLiveData<>();
-    private final MutableLiveData<String> searchQuery = new MutableLiveData<>("");
     private List<PromotedApp> allPromotedApps = new ArrayList<>();
 
     @Inject
@@ -76,20 +75,8 @@ public class HomeViewModel extends ViewModel {
         uiState.setValue(current);
     }
 
-    public void setSearchQuery(String query) {
-        searchQuery.setValue(query);
-        filterPromotedApps();
-    }
-
     private void filterPromotedApps() {
-        String query = searchQuery.getValue();
-        List<PromotedApp> filtered = new ArrayList<>();
-        for (PromotedApp app : allPromotedApps) {
-            if (query == null || query.isEmpty() ||
-                    app.name().toLowerCase().contains(query.toLowerCase())) {
-                filtered.add(app);
-            }
-        }
+        List<PromotedApp> filtered = new ArrayList<>(allPromotedApps);
         HomeUiState current = uiState.getValue();
         if (current == null) {
             current = new HomeUiState("", "", getDailyTipUseCase.invoke(), filtered);

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -168,15 +168,6 @@
                     android:text="@string/other_apps_title"
                     android:textAppearance="@style/TextAppearance.Material3.TitleMedium" />
 
-                <androidx.appcompat.widget.SearchView
-                    android:id="@+id/search_view"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="8dp"
-                    android:queryHint="@string/search_tutorials_hint"
-                    android:contentDescription="@string/search_tutorials_content_description"
-                    android:iconifiedByDefault="false" />
-
                 <HorizontalScrollView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"


### PR DESCRIPTION
## Summary
- Drop search UI from home screen layout and fragment
- Simplify HomeViewModel promoted app handling by removing query filtering

## Testing
- ⚠️ `./gradlew test` *(failed: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b613b38cfc832db9fb0badb988c92f