### PR TITLE
Add share button for promoted apps

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeFragment.java
@@ -57,6 +57,7 @@ public class HomeFragment extends Fragment {
                 itemBinding.appName.setText(app.name());
                 itemBinding.appDescription.setVisibility(android.view.View.GONE);
                 itemBinding.appButton.setOnClickListener(v -> startActivity(homeViewModel.getPromotedAppIntent(app.packageName())));
+                itemBinding.shareButton.setOnClickListener(v -> shareApp(app));
                 promotedContainer.addView(itemBinding.getRoot());
             }
         });
@@ -89,6 +90,16 @@ public class HomeFragment extends Fragment {
         shareIntent.setType("text/plain");
         shareIntent.putExtra(android.content.Intent.EXTRA_TEXT, tip);
         startActivity(android.content.Intent.createChooser(shareIntent, getString(com.d4rk.androidtutorials.java.R.string.share_using)));
+    }
+
+    private void shareApp(com.d4rk.androidtutorials.java.data.model.PromotedApp app) {
+        android.content.Intent sharingIntent = new android.content.Intent(android.content.Intent.ACTION_SEND);
+        sharingIntent.setType("text/plain");
+        String shareLink = homeViewModel.getPromotedAppIntent(app.packageName()).getData().toString();
+        String shareMessage = getString(com.d4rk.androidtutorials.java.R.string.share_message, shareLink);
+        sharingIntent.putExtra(android.content.Intent.EXTRA_TEXT, shareMessage);
+        sharingIntent.putExtra(android.content.Intent.EXTRA_SUBJECT, getString(com.d4rk.androidtutorials.java.R.string.share_subject));
+        startActivity(android.content.Intent.createChooser(sharingIntent, getString(com.d4rk.androidtutorials.java.R.string.share_using)));
     }
 
     private void loadImage(String url, android.widget.ImageView imageView) {

--- a/app/src/main/res/layout/promoted_app_item.xml
+++ b/app/src/main/res/layout/promoted_app_item.xml
@@ -12,6 +12,16 @@
         android:layout_height="match_parent"
         android:padding="8dp">
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/share_button"
+            style="@style/Widget.Material3.Button.IconButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/share"
+            app:icon="@drawable/ic_share"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/app_icon"
             android:layout_width="48dp"


### PR DESCRIPTION
## Summary
- Add share icon button to promoted app card layout
- Share promoted app Play Store link via new shareApp helper in HomeFragment

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a11ea528832d982df8057d76ea96