### PR TITLE
feat: set Google Sans Code as default code font

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/utils/FontManager.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/utils/FontManager.java
@@ -14,18 +14,20 @@ public class FontManager {
         String key = context.getString(R.string.key_monospace_font);
         String font;
         try {
-            font = prefs.getString(key, "0");
+            font = prefs.getString(key, "6");
         } catch (ClassCastException e) {
             prefs.edit().remove(key).apply();
-            font = "0";
+            font = "6";
         }
         return switch (font) {
+            case "0" -> ResourcesCompat.getFont(context, R.font.font_audiowide);
             case "1" -> ResourcesCompat.getFont(context, R.font.font_fira_code);
             case "2" -> ResourcesCompat.getFont(context, R.font.font_jetbrains_mono);
             case "3" -> ResourcesCompat.getFont(context, R.font.font_noto_sans_mono);
             case "4" -> ResourcesCompat.getFont(context, R.font.font_poppins);
             case "5" -> ResourcesCompat.getFont(context, R.font.font_roboto_mono);
-            default -> ResourcesCompat.getFont(context, R.font.font_audiowide);
+            case "6" -> ResourcesCompat.getFont(context, R.font.font_google_sans_code);
+            default -> ResourcesCompat.getFont(context, R.font.font_google_sans_code);
         };
     }
 }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -76,6 +76,7 @@
         <item>3</item>
         <item>4</item>
         <item>5</item>
+        <item>6</item>
     </string-array>
     <string-array name="code_font_entries">
         <item>@string/audiowide</item>
@@ -84,6 +85,7 @@
         <item>@string/noto_sans_mono</item>
         <item>@string/poppins</item>
         <item>@string/roboto_mono</item>
+        <item>@string/google_sans_code</item>
     </string-array>
     <string-array name="preference_bottom_navigation_bar_labels_entries">
         <item>@string/labeled</item>

--- a/app/src/main/res/values/untranslatable_strings.xml
+++ b/app/src/main/res/values/untranslatable_strings.xml
@@ -42,6 +42,7 @@
     <string name="noto_sans_mono" translatable="false">Noto Sans Mono</string>
     <string name="poppins" translatable="false">Poppins</string>
     <string name="roboto_mono" translatable="false">Roboto Mono</string>
+    <string name="google_sans_code" translatable="false">Google Sans Code</string>
     <string name="arch" translatable="false">Arch:</string>
     <string name="copyright" translatable="false">Copyright ©2023-2025, D4rK</string>
     <string name="summary_preference_settings_license" translatable="false">General Public License-3.0</string>

--- a/app/src/main/res/xml/preferences_settings.xml
+++ b/app/src/main/res/xml/preferences_settings.xml
@@ -28,7 +28,7 @@
             app:title="@string/bottom_navigation_bar_labels"
             app:useSimpleSummaryProvider="true" />
         <androidx.preference.ListPreference
-            app:defaultValue="0"
+            app:defaultValue="6"
             app:entries="@array/code_font_entries"
             app:entryValues="@array/code_font_values"
             app:icon="@drawable/ic_font_download"


### PR DESCRIPTION
## Summary
- add Google Sans Code string resource
- map new font in font manager and defaults
- set Google Sans Code as default code font selection

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a588cfb8832d948292be824ce65b