### PR TITLE
Stream quiz JSON parsing on background executor

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/DefaultQuizRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/DefaultQuizRepository.java
@@ -1,9 +1,6 @@
 package com.d4rk.androidtutorials.java.data.repository;
 
-import com.d4rk.androidtutorials.java.data.model.QuizQuestion;
 import com.d4rk.androidtutorials.java.data.source.QuizLocalDataSource;
-
-import java.util.List;
 
 /**
  * Default implementation of {@link QuizRepository} using a local data source.
@@ -17,7 +14,7 @@ public class DefaultQuizRepository implements QuizRepository {
     }
 
     @Override
-    public List<QuizQuestion> loadQuestions() {
-        return localDataSource.loadQuestions();
+    public void loadQuestions(QuestionsCallback callback) {
+        localDataSource.loadQuestions(callback::onResult);
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/QuizRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/QuizRepository.java
@@ -8,5 +8,10 @@ import java.util.List;
  * Abstraction over quiz data operations.
  */
 public interface QuizRepository {
-    List<QuizQuestion> loadQuestions();
+
+    interface QuestionsCallback {
+        void onResult(List<QuizQuestion> questions);
+    }
+
+    void loadQuestions(QuestionsCallback callback);
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/source/QuizLocalDataSource.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/source/QuizLocalDataSource.java
@@ -8,5 +8,10 @@ import java.util.List;
  * Contract for reading quiz data from local storage.
  */
 public interface QuizLocalDataSource {
-    List<QuizQuestion> loadQuestions();
+
+    interface QuestionsCallback {
+        void onResult(List<QuizQuestion> questions);
+    }
+
+    void loadQuestions(QuestionsCallback callback);
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/di/AppModule.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/di/AppModule.java
@@ -224,9 +224,9 @@ public class AppModule {
 
     @Provides
     @Singleton
-    public QuizLocalDataSource provideQuizLocalDataSource(Application application) {
+    public QuizLocalDataSource provideQuizLocalDataSource(Application application, ExecutorService executorService) {
         AssetManager manager = application.getAssets();
-        return new DefaultQuizLocalDataSource(manager);
+        return new DefaultQuizLocalDataSource(manager, executorService);
     }
 
     @Provides

--- a/app/src/main/java/com/d4rk/androidtutorials/java/domain/quiz/LoadQuizQuestionsUseCase.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/domain/quiz/LoadQuizQuestionsUseCase.java
@@ -2,17 +2,22 @@ package com.d4rk.androidtutorials.java.domain.quiz;
 
 import com.d4rk.androidtutorials.java.data.model.QuizQuestion;
 import com.d4rk.androidtutorials.java.data.repository.QuizRepository;
+
 import java.util.List;
 
 /** Loads quiz questions from assets. */
 public class LoadQuizQuestionsUseCase {
     private final QuizRepository repository;
 
+    public interface Callback {
+        void onResult(List<QuizQuestion> questions);
+    }
+
     public LoadQuizQuestionsUseCase(QuizRepository repository) {
         this.repository = repository;
     }
 
-    public List<QuizQuestion> invoke() {
-        return repository.loadQuestions();
+    public void invoke(Callback callback) {
+        repository.loadQuestions(callback::onResult);
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/tabs/ButtonsTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/tabs/ButtonsTabLayoutFragment.java
@@ -20,8 +20,10 @@ import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
 import com.google.android.gms.ads.AdRequest;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
@@ -61,14 +63,15 @@ public class ButtonsTabLayoutFragment extends Fragment {
         for (Map.Entry<Integer, CodeView> entry : buttonXMLResources.entrySet()) {
             Integer resourceId = entry.getKey();
             CodeView codeView = entry.getValue();
-            try (InputStream inputStream = getResources().openRawResource(resourceId)) {
-                byte[] bytes = new byte[inputStream.available()];
-                int result = inputStream.read(bytes);
-                if (result != -1) {
-                    String text = new String(bytes, StandardCharsets.UTF_8);
-                    codeView.setText(text);
-                    CodeHighlighter.applyXmlTheme(codeView);
+            try (InputStream inputStream = getResources().openRawResource(resourceId);
+                 BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+                StringBuilder builder = new StringBuilder();
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    builder.append(line).append('\n');
                 }
+                codeView.setText(builder.toString());
+                CodeHighlighter.applyXmlTheme(codeView);
             } catch (IOException e) {
                 Log.e("ButtonsTab", "Error reading button resource", e);
             }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/quiz/QuizViewModel.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/quiz/QuizViewModel.java
@@ -7,6 +7,7 @@ import androidx.lifecycle.MutableLiveData;
 import com.d4rk.androidtutorials.java.data.model.QuizQuestion;
 import com.d4rk.androidtutorials.java.domain.quiz.LoadQuizQuestionsUseCase;
 
+import java.util.Collections;
 import java.util.List;
 
 import dagger.hilt.android.lifecycle.HiltViewModel;
@@ -18,7 +19,7 @@ import javax.inject.Inject;
 @HiltViewModel
 public class QuizViewModel extends ViewModel {
 
-    private final List<QuizQuestion> questions;
+    private final MutableLiveData<List<QuizQuestion>> questions = new MutableLiveData<>(Collections.emptyList());
     private final MutableLiveData<Integer> currentIndex = new MutableLiveData<>(0);
     private final MutableLiveData<Integer> score = new MutableLiveData<>(0);
     private final LoadQuizQuestionsUseCase loadQuizQuestionsUseCase;
@@ -26,13 +27,14 @@ public class QuizViewModel extends ViewModel {
     @Inject
     public QuizViewModel(LoadQuizQuestionsUseCase loadQuizQuestionsUseCase) {
         this.loadQuizQuestionsUseCase = loadQuizQuestionsUseCase;
-        questions = loadQuizQuestionsUseCase.invoke();
+        loadQuizQuestionsUseCase.invoke(result -> questions.postValue(result));
     }
 
     public QuizQuestion getCurrentQuestion() {
-        if (questions.isEmpty()) return null;
+        List<QuizQuestion> list = questions.getValue();
+        if (list == null || list.isEmpty()) return null;
         int index = currentIndex.getValue();
-        return questions.get(Math.min(index, questions.size() - 1));
+        return list.get(Math.min(index, list.size() - 1));
     }
 
     public LiveData<Integer> getCurrentIndex() {
@@ -41,6 +43,10 @@ public class QuizViewModel extends ViewModel {
 
     public LiveData<Integer> getScore() {
         return score;
+    }
+
+    public LiveData<List<QuizQuestion>> getQuestions() {
+        return questions;
     }
 
     public void answer(int optionIndex) {
@@ -52,6 +58,7 @@ public class QuizViewModel extends ViewModel {
     }
 
     public int getTotalQuestions() {
-        return questions.size();
+        List<QuizQuestion> list = questions.getValue();
+        return list != null ? list.size() : 0;
     }
 }


### PR DESCRIPTION
## Summary
- Stream quiz_questions.json with JsonReader on a background ExecutorService and return results via callback
- Switch repository, use case, and view model to asynchronous callbacks
- Replace raw resource reads with buffered streams to avoid InputStream.available

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b703460bb8832d9c397852b8c82bfd