### PR TITLE
Offload promoted app parsing to background thread

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/source/DefaultHomeRemoteDataSource.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/source/DefaultHomeRemoteDataSource.java
@@ -1,5 +1,7 @@
 package com.d4rk.androidtutorials.java.data.source;
 
+import android.os.Handler;
+import android.os.Looper;
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.JsonObjectRequest;
@@ -12,6 +14,8 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 /**
  * Volley based implementation of {@link HomeRemoteDataSource}.
@@ -20,10 +24,14 @@ public class DefaultHomeRemoteDataSource implements HomeRemoteDataSource {
 
     private final RequestQueue requestQueue;
     private final String apiUrl;
+    private final Executor executor;
+    private final Handler mainHandler;
 
     public DefaultHomeRemoteDataSource(RequestQueue requestQueue, String apiUrl) {
         this.requestQueue = requestQueue;
         this.apiUrl = apiUrl;
+        this.executor = Executors.newSingleThreadExecutor();
+        this.mainHandler = new Handler(Looper.getMainLooper());
     }
 
     @Override
@@ -32,29 +40,34 @@ public class DefaultHomeRemoteDataSource implements HomeRemoteDataSource {
                 Request.Method.GET,
                 apiUrl,
                 null,
-                response -> {
-                    List<PromotedApp> result = new ArrayList<>();
-                    try {
-                        JSONArray apps = response.getJSONObject("data").getJSONArray("apps");
-                        for (int i = 0; i < apps.length(); i++) {
-                            JSONObject obj = apps.getJSONObject(i);
-                            String pkg = obj.getString("packageName");
-                            if (pkg.contains("com.d4rk.androidtutorials")) {
-                                continue;
-                            }
-                            result.add(new PromotedApp(
-                                    obj.getString("name"),
-                                    pkg,
-                                    obj.getString("iconLogo")
-                            ));
-                        }
-                    } catch (JSONException e) {
-                        result = Collections.emptyList();
-                    }
-                    callback.onResult(result);
-                },
-                error -> callback.onResult(Collections.emptyList())
+                response -> executor.execute(() -> {
+                    List<PromotedApp> result = parseResponse(response);
+                    mainHandler.post(() -> callback.onResult(result));
+                }),
+                error -> mainHandler.post(() -> callback.onResult(Collections.emptyList()))
         );
         requestQueue.add(request);
+    }
+
+    private List<PromotedApp> parseResponse(JSONObject response) {
+        List<PromotedApp> result = new ArrayList<>();
+        try {
+            JSONArray apps = response.getJSONObject("data").getJSONArray("apps");
+            for (int i = 0; i < apps.length(); i++) {
+                JSONObject obj = apps.getJSONObject(i);
+                String pkg = obj.getString("packageName");
+                if (pkg.contains("com.d4rk.androidtutorials")) {
+                    continue;
+                }
+                result.add(new PromotedApp(
+                        obj.getString("name"),
+                        pkg,
+                        obj.getString("iconLogo")
+                ));
+            }
+        } catch (JSONException e) {
+            result = Collections.emptyList();
+        }
+        return result;
     }
 }


### PR DESCRIPTION
## Summary
- Run heavy promoted apps JSON parsing on a background executor
- Deliver parsed results back to the main thread before invoking callbacks

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fc6f0e6c832dbe8ce3691360d5b4