### PR TITLE
Add profile picture content description with translations

### DIFF
--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -48,7 +48,8 @@
                         android:layout_height="48dp"
                         android:layout_marginEnd="16dp"
                         android:scaleType="centerCrop"
-                        android:src="@drawable/dev_logo" />
+                        android:src="@drawable/dev_logo"
+                        android:contentDescription="@string/profile_picture_desc" />
 
                     <androidx.appcompat.widget.LinearLayoutCompat
                         android:layout_width="0dp"

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -13,6 +13,7 @@
     <string name="home">الرئيسية</string>
     <string name="announcement_title">تطبيق جديد وصل.</string>
     <string name="announcement_subtitle">شوف أحدث تطبيق لشروحات أندرويد ستوديو. اتعلم Jetpack Compose، و Material 3، وغيرهم.</string>
+    <string name="profile_picture_desc">صورة ملف تعريف المطور</string>
     <string name="main_card_title">اكتشف شروحات أندرويد ستوديو</string>
     <string name="main_card_subtitle">بإصدارات Kotlin و Java</string>
     <string name="main_card_description">تم تحديث إصدار Kotlin بدروس ديناميكية ومساعد ذكاء اصطناعي والمزيد. جرب مستقبل تطوير تطبيقات أندرويد.</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -13,6 +13,7 @@
     <string name="home">Начало</string>
     <string name="announcement_title">Ново приложение е тук.</string>
     <string name="announcement_subtitle">Разгледайте най-новото приложение Android Studio Tutorials. Научете Jetpack Compose, Material 3 и още.</string>
+    <string name="profile_picture_desc">Снимка на профила на разработчика</string>
     <string name="main_card_title">Открийте уроците за Android Studio</string>
     <string name="main_card_subtitle">Представяме издания за Kotlin и Java</string>
     <string name="main_card_description">Изданието за Kotlin е актуализирано с динамични уроци, AI асистент и още. Изживейте бъдещето на разработката за Android.</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -13,6 +13,7 @@
     <string name="home">হোম</string>
     <string name="announcement_title">একটি নতুন অ্যাপ এসেছে.</string>
     <string name="announcement_subtitle">সর্বশেষ অ্যান্ড্রয়েড স্টুডিও টিউটোরিয়াল অ্যাপটি দেখুন। জেটপ্যাক কম্পোজ, ম্যাটেরিয়াল ৩ এবং আরও অনেক কিছু শিখুন।</string>
+    <string name="profile_picture_desc">বিকাশকারী প্রোফাইল ছবি</string>
     <string name="main_card_title">অ্যান্ড্রয়েড স্টুডিও টিউটোরিয়াল আবিষ্কার করুন</string>
     <string name="main_card_subtitle">কোটলিন এবং জাভা সংস্করণ সহ</string>
     <string name="main_card_description">কোটলিন সংস্করণটি ডাইনামিক পাঠ, এআই সহকারী এবং আরও অনেক কিছু দিয়ে আপডেট করা হয়েছে। অ্যান্ড্রয়েড ডেভেলপমেন্টের ভবিষ্যৎ অভিজ্ঞতা নিন.</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -13,6 +13,7 @@
     <string name="home">Startseite</string>
     <string name="announcement_title">Eine neue App ist da.</string>
     <string name="announcement_subtitle">Schau dir die neueste Android Studio Tutorials App an. Lerne Jetpack Compose, Material 3 und mehr.</string>
+    <string name="profile_picture_desc">Entwicklerprofilbild</string>
     <string name="main_card_title">Entdecke Android Studio Tutorials</string>
     <string name="main_card_subtitle">Mit Kotlin- und Java-Editionen</string>
     <string name="main_card_description">Die Kotlin-Edition wurde mit dynamischen Lektionen, KI-Assistent und mehr aktualisiert. Erlebe die Zukunft der Android-Entwicklung.</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -13,6 +13,7 @@
     <string name="home">Inicio</string>
     <string name="announcement_title">Hay una nueva aplicación.</string>
     <string name="announcement_subtitle">Echa un vistazo a la última aplicación Android Studio Tutorials. Aprende Jetpack Compose, Material 3 y más.</string>
+    <string name="profile_picture_desc">Foto de perfil de desarrollador</string>
     <string name="main_card_title">Descubre los tutoriales de Android Studio</string>
     <string name="main_card_subtitle">Con ediciones para Kotlin y Java</string>
     <string name="main_card_description">La edición de Kotlin se ha actualizado con lecciones dinámicas, asistente de IA y más. Experimenta el futuro del desarrollo de Android.</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -13,6 +13,7 @@
     <string name="home">Inicio</string>
     <string name="announcement_title">Llegó una nueva app.</string>
     <string name="announcement_subtitle">Échale un ojo a la nueva app de Tutoriales de Android Studio. Aprende Jetpack Compose, Material 3 y más.</string>
+    <string name="profile_picture_desc">Foto de perfil de desarrollador</string>
     <string name="main_card_title">Descubre los Tutoriales de Android Studio</string>
     <string name="main_card_subtitle">Con ediciones de Kotlin y Java</string>
     <string name="main_card_description">La edición de Kotlin ha sido actualizada con lecciones dinámicas, asistente de IA y más. Experimenta el futuro del desarrollo de Android.</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -13,6 +13,7 @@
     <string name="home">Home</string>
     <string name="announcement_title">May Bagong App.</string>
     <string name="announcement_subtitle">Tingnan ang pinakabagong Android Studio Tutorials app. Alamin ang Jetpack Compose, Material 3, at marami pa.</string>
+    <string name="profile_picture_desc">Larawan ng profile ng developer</string>
     <string name="main_card_title">Tuklasin ang Android Studio Tutorials</string>
     <string name="main_card_subtitle">Nagtatampok ng mga Edisyon ng Kotlin at Java</string>
     <string name="main_card_description">Ang Kotlin Edition ay na-update na may mga dynamic na aralin, AI assistant, at marami pa. Damhin ang hinaharap ng Android development.</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -13,6 +13,7 @@
     <string name="home">Accueil</string>
     <string name="announcement_title">Une nouvelle application est là .</string>
     <string name="announcement_subtitle">Découvrez la dernière application Android Studio Tutorials. Apprenez Jetpack Compose, Material 3, et plus encore.</string>
+    <string name="profile_picture_desc">Image de profil de développeur</string>
     <string name="main_card_title">Découvrez les tutoriels Android Studio</string>
     <string name="main_card_subtitle">Avec les éditions Kotlin et Java</string>
     <string name="main_card_description">L\'édition Kotlin a été mise à jour avec des leçons dynamiques, un assistant IA, et plus encore. Découvrez l\'avenir du développement Android .</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -2,6 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="announcement_title">एक नया ऐप यहाँ है.</string>
     <string name="announcement_subtitle">नवीनतम Android Studio ट्यूटोरियल ऐप देखें।</string>
+    <string name="profile_picture_desc">डेवलपर प्रोफ़ाइल चित्र</string>
     <string name="main_card_title">Android Studio ट्यूटोरियल खोजें</string>
     <string name="main_card_subtitle">कोटलिन और जावा संस्करणों की विशेषता</string>
     <string name="main_card_description">कोटलिन संस्करण को गतिशील पाठों, एआई सहायक और बहुत कुछ के साथ अपडेट किया गया है। एंड्रॉइड डेवलपमेंट के भविष्य का अनुभव करें.</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -18,4 +18,5 @@
     <string name="add_note">Jegyzet hozzáadása</string>
     <string name="summary_preference_android_studio_room_database">Egyszerű jegyzetek tárolása a Room használatával, amely egy absztrakciós réteg a SQLite felett.</string>
     <string name="summary_room_database">A Room egy perzisztencia könyvtár, amely objektumtérképezési réteget biztosít a SQLite felett. Ez a példa megmutatja, hogyan lehet jegyzeteket menteni és megjeleníteni.</string>
+    <string name="profile_picture_desc">Fejlesztő profilkép</string>
 </resources>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -2,6 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="announcement_title">Aplikasi Baru Telah Tiba.</string>
     <string name="announcement_subtitle">Lihat aplikasi Android Studio Tutorials terbaru.</string>
+    <string name="profile_picture_desc">Gambar profil pengembang</string>
     <string name="main_card_title">Temukan Tutorial Android Studio</string>
     <string name="main_card_subtitle">Menampilkan Edisi Kotlin dan Java</string>
     <string name="main_card_description">Edisi Kotlin telah diperbarui dengan pelajaran dinamis, asisten AI, dan banyak lagi. Rasakan masa depan pengembangan Android.</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -18,4 +18,5 @@
     <string name="add_note">Aggiungi nota</string>
     <string name="summary_preference_android_studio_room_database">Mantieni semplici note utilizzando Room, un livello di astrazione sopra SQLite.</string>
     <string name="summary_room_database">Room è una libreria di persistenza che fornisce un livello di mapping degli oggetti sopra SQLite. Questo esempio mostra come salvare e visualizzare note.</string>
+    <string name="profile_picture_desc">Immagine del profilo sviluppatore</string>
 </resources>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -18,4 +18,5 @@
     <string name="add_note">メモを追加</string>
     <string name="summary_preference_android_studio_room_database">SQLite の上にある抽象化レイヤーである Room を使用して簡単なメモを保持します。</string>
     <string name="summary_room_database">Room は SQLite 上にオブジェクトマッピングレイヤーを提供する永続化ライブラリです。この例ではメモを保存して表示する方法を示します。</string>
+    <string name="profile_picture_desc">開発者プロフィール写真</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -13,6 +13,7 @@
     <string name="home">홈</string>
     <string name="announcement_title">새로운 앱이 출시되었습니다.</string>
     <string name="announcement_subtitle">최신 Android Studio 튜토리얼 앱을 확인해보세요. Jetpack Compose, Material 3 등을 배워보세요.</string>
+    <string name="profile_picture_desc">개발자 프로필 사진</string>
     <string name="main_card_title">Android Studio 튜토리얼 살펴보기</string>
     <string name="main_card_subtitle">Kotlin 및 Java 에디션 제공</string>
     <string name="main_card_description">Kotlin 에디션이 동적 강의, AI 어시스턴트 등으로 업데이트되었습니다. Android 개발의 미래를 경험해보세요.</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -18,4 +18,5 @@
     <string name="add_note">Dodaj notatkę</string>
     <string name="summary_preference_android_studio_room_database">Przechowuj proste notatki za pomocą Room, warstwy abstrakcji nad SQLite.</string>
     <string name="summary_room_database">Room to biblioteka trwałości, która zapewnia warstwę mapowania obiektów na SQLite. Ten przykład pokazuje, jak zapisywać i wyświetlać notatki.</string>
+    <string name="profile_picture_desc">Zdjęcie profilowe programisty</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -13,6 +13,7 @@
     <string name="home">Início</string>
     <string name="announcement_title">Um Novo Aplicativo Chegou.</string>
     <string name="announcement_subtitle">Confira o mais recente aplicativo de Tutoriais do Android Studio. Aprenda Jetpack Compose, Material 3 e muito mais.</string>
+    <string name="profile_picture_desc">Imagem do perfil do desenvolvedor</string>
     <string name="main_card_title">Descubra os Tutoriais do Android Studio</string>
     <string name="main_card_subtitle">Apresentando as edições Kotlin e Java</string>
     <string name="main_card_description">A Edição Kotlin foi atualizada com lições dinâmicas, assistente de IA e muito mais. Experimente o futuro do desenvolvimento Android.</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -2,6 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="announcement_title">A sosit o aplicație nouă.</string>
     <string name="announcement_subtitle">Descoperă cea mai recentă aplicație Android Studio Tutorials.</string>
+    <string name="profile_picture_desc">Poza de profil pentru dezvoltatori</string>
     <string name="main_card_title">Descoperă Tutorialele Android Studio</string>
     <string name="main_card_subtitle">Disponibilă în edițiile Kotlin și Java</string>
     <string name="main_card_description">Ediția Kotlin a fost actualizată cu lecții dinamice, asistent AI și multe altele. Experimentează viitorul dezvoltării Android.</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -2,6 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="announcement_title">Новое приложение уже здесь.</string>
     <string name="announcement_subtitle">Оцените последнее приложение Android Studio Tutorials.</string>
+    <string name="profile_picture_desc">Изображение профиля разработчика</string>
     <string name="main_card_title">Откройте для себя уроки Android Studio</string>
     <string name="main_card_subtitle">Включая версии на Kotlin и Java</string>
     <string name="main_card_description">Версия Kotlin была обновлена динамическими уроками, помощником с ИИ и многим другим. Ощутите будущее разработки Android.</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -13,6 +13,7 @@
     <string name="home">Hem</string>
     <string name="announcement_title">En ny app har kommit.</string>
     <string name="announcement_subtitle">Kolla in den senaste appen Android Studio Tutorials. Lär dig Jetpack Compose, Material 3 och mer.</string>
+    <string name="profile_picture_desc">Utvecklarprofilbild</string>
     <string name="main_card_title">Upptäck Android Studio Tutorials</string>
     <string name="main_card_subtitle">Med Kotlin- och Java-utgåvor</string>
     <string name="main_card_description">Kotlin-utgåvan har uppdaterats med dynamiska lektioner, AI-assistent och mer. Upplev framtiden för Android-utveckling.</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -13,6 +13,7 @@
     <string name="home">หน้าแรก</string>
     <string name="announcement_title">แอปใหม่มาแล้ว.</string>
     <string name="announcement_subtitle">พบกับแอป Android Studio Tutorials ล่าสุด เรียนรู้ Jetpack Compose, Material 3 และอื่นๆ</string>
+    <string name="profile_picture_desc">รูปโปรไฟล์นักพัฒนา</string>
     <string name="main_card_title">ค้นพบ Android Studio Tutorials</string>
     <string name="main_card_subtitle">นำเสนอฉบับ Kotlin และ Java</string>
     <string name="main_card_description">ฉบับ Kotlin ได้รับการอัปเดตด้วยบทเรียนแบบไดนามิก, ผู้ช่วย AI และอื่นๆ สัมผัสอนาคตของการพัฒนา Android.</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -13,6 +13,7 @@
     <string name="home">Ana Sayfa</string>
     <string name="announcement_title">Yeni Bir Uygulama Geldi.</string>
     <string name="announcement_subtitle">En son Android Studio Eğitimleri uygulamasını inceleyin. Jetpack Compose, Material 3 ve daha fazlasını öğrenin.</string>
+    <string name="profile_picture_desc">Geliştirici Profil Resmi</string>
     <string name="main_card_title">Android Studio Eğitimlerini Keşfedin</string>
     <string name="main_card_subtitle">Kotlin ve Java Sürümleriyle</string>
     <string name="main_card_description">Kotlin Sürümü dinamik dersler, yapay zeka asistanı ve daha fazlasıyla güncellendi. Android geliştirmenin geleceğini deneyimleyin.</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -13,6 +13,7 @@
     <string name="home">Головна</string>
     <string name="announcement_title">Новий додаток вже тут.</string>
     <string name="announcement_subtitle">Перегляньте найновіший додаток Android Studio Tutorials. Вивчайте Jetpack Compose, Material 3 та багато іншого.</string>
+    <string name="profile_picture_desc">Зображення профілю розробника</string>
     <string name="main_card_title">Відкрийте для себе посібники з Android Studio</string>
     <string name="main_card_subtitle">З версіями на Kotlin та Java</string>
     <string name="main_card_description">Версія на Kotlin оновлена динамічними уроками, ШІ-асистентом та іншим. Відчуйте майбутнє розробки на Android.</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -13,6 +13,7 @@
     <string name="home">ہوم</string>
     <string name="announcement_title">ایک نئی ایپ آ گئی ہے.</string>
     <string name="announcement_subtitle">اینڈرائیڈ اسٹوڈیو ٹیوٹوریلز کی تازہ ترین ایپ دیکھیں۔ جیٹ پیک کمپوز، میٹیریل 3، اور بہت کچھ سیکھیں۔</string>
+    <string name="profile_picture_desc">ڈویلپر پروفائل تصویر</string>
     <string name="main_card_title">اینڈرائیڈ اسٹوڈیو ٹیوٹوریلز دریافت کریں</string>
     <string name="main_card_subtitle">کوٹلن اور جاوا ایڈیشنز کے ساتھ</string>
     <string name="main_card_description">کوٹلن ایڈیشن کو ڈائنامک اسباق، AI اسسٹنٹ، اور بہت کچھ کے ساتھ اپ ڈیٹ کیا گیا ہے۔ اینڈرائیڈ ڈیولپمنٹ کے مستقبل کا تجربہ کریں.</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -13,6 +13,7 @@
     <string name="home">Trang chủ</string>
     <string name="announcement_title">Một ứng dụng mới đã ra mắt.</string>
     <string name="announcement_subtitle">Hãy xem ứng dụng Hướng dẫn Android Studio mới nhất. Tìm hiểu Jetpack Compose, Material 3, v.v.</string>
+    <string name="profile_picture_desc">Hình ảnh hồ sơ nhà phát triển</string>
     <string name="main_card_title">Khám phá Hướng dẫn Android Studio</string>
     <string name="main_card_subtitle">Bao gồm các phiên bản Kotlin và Java</string>
     <string name="main_card_description">Phiên bản Kotlin đã được cập nhật với các bài học động, trợ lý AI, v.v. Trải nghiệm tương lai của phát triển Android.</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -13,6 +13,7 @@
     <string name="home">首頁</string>
     <string name="announcement_title">新應用程式來了！</string>
     <string name="announcement_subtitle">快來看看最新的 Android Studio 教學應用程式。學習 Jetpack Compose、Material 3 等等。</string>
+    <string name="profile_picture_desc">開發人員個人資料圖片</string>
     <string name="main_card_title">探索 Android Studio 教學</string>
     <string name="main_card_subtitle">包含 Kotlin 和 Java 版本</string>
     <string name="main_card_description">Kotlin 版本已更新，增加了動態課程、AI 助理等功能。體驗 Android 開發的未來！</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="home">Home</string>
     <string name="announcement_title">A new app is here</string>
     <string name="announcement_subtitle">Check out the latest Android Studio Tutorials app. Learn Jetpack Compose, Material 3, and more.</string>
+    <string name="profile_picture_desc">Developer profile picture</string>
     <string name="main_card_title">Discover Android Studio tutorials</string>
     <string name="main_card_subtitle">Featuring Kotlin and Java editions</string>
     <string name="main_card_description">The Kotlin Edition has been updated with dynamic lessons, AI assistant, and more. Experience the future of Android development.</string>


### PR DESCRIPTION
## Summary
- add content description to profile image on home fragment
- provide `profile_picture_desc` string and translations across supported locales

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b806880238832d9c27ca8ebca61dc1