### PR TITLE
Add missing translations for new features

### DIFF
--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -120,6 +120,25 @@
     <string name="view_recent_changes">Legutóbbi változások megtekintése</string>
     <string name="open_vcs_popup">VCS felugró ablak megnyitása</string>
     <string name="more_about_shortcuts">További információk a gyorsbillentyűkről</string>
+    <string name="history_of_android">Az Android története</string>
+    <string name="history">Történet</string>
+    <string name="features">Funkciók</string>
+
+    <string name="android_sdk">Android SDK-k</string>
+    <string name="android_versions">Android-verziók</string>
+
+    <string name="view_binding">View Binding</string>
+    <string name="setup_instructions">Beállítási utasítások</string>
+    <string name="use_view_binding_in_activities">View Binding használata az aktivitásokban</string>
+    <string name="use_view_binding_in_fragments">View Binding használata a fragmentekben</string>
+    <string name="more_about_view_binding">További információ a View Bindingről</string>
+
+    <string name="permission_dialog_example">Engedélykérő párbeszéd példája</string>
+    <string name="more_about_permissions">További információ az engedélyekről</string>
+
+    <string name="per_app_language_preferences">Alkalmazásonkénti nyelvi beállítások</string>
+
+    <string name="predictive_back_gesture">Prediktív visszalépési gesztus</string>
     <string name="im_step1_desc">Képernyőkép az Új projekt gombbal az Android Studioban.</string>
     <string name="im_step2_desc">Képernyőkép a projekt beállításakor az aktivitástípus választásáról.</string>
     <string name="im_step3_desc">Képernyőkép az alkalmazás neve, csomagja, nyelve és minimum SDK mezőiről.</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -120,6 +120,25 @@
     <string name="view_recent_changes">Visualizza modifiche recenti</string>
     <string name="open_vcs_popup">Apri pop-up VCS</string>
     <string name="more_about_shortcuts">Altri dettagli sulle scorciatoie</string>
+    <string name="history_of_android">Storia di Android</string>
+    <string name="history">Storia</string>
+    <string name="features">Funzionalità</string>
+
+    <string name="android_sdk">Android SDK</string>
+    <string name="android_versions">Versioni di Android</string>
+
+    <string name="view_binding">View Binding</string>
+    <string name="setup_instructions">Istruzioni di configurazione</string>
+    <string name="use_view_binding_in_activities">Usa View Binding nelle attività</string>
+    <string name="use_view_binding_in_fragments">Usa View Binding nei frammenti</string>
+    <string name="more_about_view_binding">Ulteriori informazioni su View Binding</string>
+
+    <string name="permission_dialog_example">Esempio di dialogo per i permessi</string>
+    <string name="more_about_permissions">Ulteriori informazioni sui permessi</string>
+
+    <string name="per_app_language_preferences">Preferenze di lingua per app</string>
+
+    <string name="predictive_back_gesture">Gesto indietro predittivo</string>
     <string name="im_step1_desc">Screenshot che mostra il pulsante Nuovo progetto in Android Studio.</string>
     <string name="im_step2_desc">Screenshot che mostra la selezione del tipo di attività durante la configurazione del progetto.</string>
     <string name="im_step3_desc">Screenshot che mostra i campi nome app, pacchetto, lingua e SDK minimo.</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -120,6 +120,25 @@
     <string name="view_recent_changes">最近の変更を表示</string>
     <string name="open_vcs_popup">VCS ポップアップを開く</string>
     <string name="more_about_shortcuts">ショートカットの詳細</string>
+    <string name="history_of_android">Android の歴史</string>
+    <string name="history">歴史</string>
+    <string name="features">機能</string>
+
+    <string name="android_sdk">Android SDK</string>
+    <string name="android_versions">Android のバージョン</string>
+
+    <string name="view_binding">View Binding</string>
+    <string name="setup_instructions">セットアップ手順</string>
+    <string name="use_view_binding_in_activities">アクティビティで View Binding を使用</string>
+    <string name="use_view_binding_in_fragments">フラグメントで View Binding を使用</string>
+    <string name="more_about_view_binding">View Binding について詳しく</string>
+
+    <string name="permission_dialog_example">権限ダイアログの例</string>
+    <string name="more_about_permissions">権限についてさらに詳しく</string>
+
+    <string name="per_app_language_preferences">アプリごとの言語設定</string>
+
+    <string name="predictive_back_gesture">予測型戻るジェスチャー</string>
     <string name="im_step1_desc">Android Studio の新規プロジェクトボタンを示すスクリーンショット。</string>
     <string name="im_step2_desc">プロジェクト設定中のアクティビティタイプ選択を示すスクリーンショット。</string>
     <string name="im_step3_desc">アプリ名、パッケージ、言語、最小 SDK の入力欄を示すスクリーンショット。</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -120,6 +120,25 @@
     <string name="view_recent_changes">Wyświetl ostatnie zmiany</string>
     <string name="open_vcs_popup">Otwórz okno VCS</string>
     <string name="more_about_shortcuts">Więcej o skrótach</string>
+    <string name="history_of_android">Historia Androida</string>
+    <string name="history">Historia</string>
+    <string name="features">Funkcje</string>
+
+    <string name="android_sdk">Android SDK</string>
+    <string name="android_versions">Wersje Androida</string>
+
+    <string name="view_binding">View Binding</string>
+    <string name="setup_instructions">Instrukcje konfiguracji</string>
+    <string name="use_view_binding_in_activities">Użyj View Binding w aktywnościach</string>
+    <string name="use_view_binding_in_fragments">Użyj View Binding we fragmentach</string>
+    <string name="more_about_view_binding">Więcej o View Binding</string>
+
+    <string name="permission_dialog_example">Przykład okna dialogowego uprawnień</string>
+    <string name="more_about_permissions">Więcej o uprawnieniach</string>
+
+    <string name="per_app_language_preferences">Preferencje językowe dla poszczególnych aplikacji</string>
+
+    <string name="predictive_back_gesture">Predykcyjny gest cofania</string>
     <string name="im_step1_desc">Zrzut ekranu pokazujący przycisk Nowy projekt w Android Studio.</string>
     <string name="im_step2_desc">Zrzut ekranu pokazujący wybór typu aktywności podczas konfiguracji projektu.</string>
     <string name="im_step3_desc">Zrzut ekranu pokazujący pola nazwy aplikacji, pakietu, języka i minimalnego SDK.</string>


### PR DESCRIPTION
## Summary
- Provide Japanese, Hungarian, Italian, and Polish translations for history, view binding, permissions, and predictive back gesture strings.

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b859192994832d9053bcb77b6fd8e1