### PR TITLE
Add translations for layout and button strings

### DIFF
--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -148,4 +148,46 @@
     <string name="add_note">Jegyzet hozzáadása</string>
     <string name="summary_preference_android_studio_room_database">Egyszerű jegyzetek tárolása a Room használatával, amely egy absztrakciós réteg a SQLite felett.</string>
     <string name="summary_room_database">A Room egy perzisztencia könyvtár, amely objektumtérképezési réteget biztosít a SQLite felett. Ez a példa megmutatja, hogyan lehet jegyzeteket menteni és megjeleníteni.</string>
+
+    <string name="layouts">Elrendezések és nézetek</string>
+
+    <string name="linear_layout">Lineáris elrendezés</string>
+
+    <string name="vertical">Függőleges</string>
+    <string name="horizontal">Vízszintes</string>
+    <string name="layout_preview">Elrendezés előnézete</string>
+    <string name="no_java_code_needed">Ehhez az aktivitáshoz nincs szükség Java kódra.</string>
+
+    <string name="relative_layout">Relatív elrendezés</string>
+
+    <string name="table_layout">Táblázatos elrendezés</string>
+
+    <string name="grid_view">Rácsnézet</string>
+
+    <string name="image_view">Képnézet</string>
+
+    <string name="web_view">Webnézet</string>
+
+    <string name="buttons_and_switches">Gombok és kapcsolók</string>
+    <string name="buttons">Gombok</string>
+    <string name="button">Gomb</string>
+    <string name="button_normal">1. gomb (normál)</string>
+    <string name="button_outlined">2. gomb (körvonalas)</string>
+    <string name="button_elevated">3. gomb (emelt)</string>
+    <string name="button_normal_icon">4. gomb (normál ikon)</string>
+    <string name="button_outlined_icon">5. gomb (körvonalas ikon)</string>
+    <string name="button_elevated_icon">6. gomb (emelt ikon)</string>
+    <string name="extended_floating_button_primary">Kiterjesztett lebegő gomb 1 (elsődleges)</string>
+    <string name="extended_floating_button_secondary">Kiterjesztett lebegő gomb 2 (másodlagos)</string>
+    <string name="extended_floating_button_surface">Kiterjesztett lebegő gomb 3 (felület)</string>
+    <string name="extended_floating_button_tertiary">Kiterjesztett lebegő gomb 4 (harmadlagos)</string>
+    <string name="extended_floating_button_primary_icon">Kiterjesztett lebegő gomb 5 (elsődleges ikon)</string>
+    <string name="extended_floating_button_secondary_icon">Kiterjesztett lebegő gomb 6 (másodlagos ikon)</string>
+    <string name="extended_floating_button_surface_icon">Kiterjesztett lebegő gomb 7 (felületi ikon)</string>
+    <string name="extended_floating_button_tertiary_icon">Kiterjesztett lebegő gomb 8 (harmadlagos ikon)</string>
+    <string name="floating_button_primary_icon">Lebegő gomb 1 (elsődleges)</string>
+    <string name="floating_button_secondary_icon">Lebegő gomb 2 (másodlagos)</string>
+    <string name="floating_button_surface_icon">Lebegő gomb 3 (felület)</string>
+    <string name="floating_button_tertiary_icon">Lebegő gomb 4 (harmadlagos)</string>
+    <string name="same_code_buttons">Használd ezt a Java kódot minden gombtípushoz.</string>
 </resources>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -148,4 +148,46 @@
     <string name="add_note">Aggiungi nota</string>
     <string name="summary_preference_android_studio_room_database">Mantieni semplici note utilizzando Room, un livello di astrazione sopra SQLite.</string>
     <string name="summary_room_database">Room è una libreria di persistenza che fornisce un livello di mapping degli oggetti sopra SQLite. Questo esempio mostra come salvare e visualizzare note.</string>
+
+    <string name="layouts">Layout e viste</string>
+
+    <string name="linear_layout">Layout lineare</string>
+
+    <string name="vertical">Verticale</string>
+    <string name="horizontal">Orizzontale</string>
+    <string name="layout_preview">Anteprima del layout</string>
+    <string name="no_java_code_needed">Nessun codice Java richiesto per questa attività.</string>
+
+    <string name="relative_layout">Layout relativo</string>
+
+    <string name="table_layout">Layout tabella</string>
+
+    <string name="grid_view">Vista griglia</string>
+
+    <string name="image_view">Vista immagine</string>
+
+    <string name="web_view">Vista Web</string>
+
+    <string name="buttons_and_switches">Pulsanti e interruttori</string>
+    <string name="buttons">Pulsanti</string>
+    <string name="button">Pulsante</string>
+    <string name="button_normal">Pulsante 1 (normale)</string>
+    <string name="button_outlined">Pulsante 2 (con contorno)</string>
+    <string name="button_elevated">Pulsante 3 (elevato)</string>
+    <string name="button_normal_icon">Pulsante 4 (normale con icona)</string>
+    <string name="button_outlined_icon">Pulsante 5 (con contorno e icona)</string>
+    <string name="button_elevated_icon">Pulsante 6 (elevato con icona)</string>
+    <string name="extended_floating_button_primary">Pulsante flottante esteso 1 (primario)</string>
+    <string name="extended_floating_button_secondary">Pulsante flottante esteso 2 (secondario)</string>
+    <string name="extended_floating_button_surface">Pulsante flottante esteso 3 (superficie)</string>
+    <string name="extended_floating_button_tertiary">Pulsante flottante esteso 4 (terziario)</string>
+    <string name="extended_floating_button_primary_icon">Pulsante flottante esteso 5 (icona primaria)</string>
+    <string name="extended_floating_button_secondary_icon">Pulsante flottante esteso 6 (icona secondaria)</string>
+    <string name="extended_floating_button_surface_icon">Pulsante flottante esteso 7 (icona superficie)</string>
+    <string name="extended_floating_button_tertiary_icon">Pulsante flottante esteso 8 (icona terziaria)</string>
+    <string name="floating_button_primary_icon">Pulsante flottante 1 (primario)</string>
+    <string name="floating_button_secondary_icon">Pulsante flottante 2 (secondario)</string>
+    <string name="floating_button_surface_icon">Pulsante flottante 3 (superficie)</string>
+    <string name="floating_button_tertiary_icon">Pulsante flottante 4 (terziario)</string>
+    <string name="same_code_buttons">Usa questo codice Java per tutti i tipi di pulsanti.</string>
 </resources>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -148,4 +148,46 @@
     <string name="add_note">メモを追加</string>
     <string name="summary_preference_android_studio_room_database">SQLite の上にある抽象化レイヤーである Room を使用して簡単なメモを保持します。</string>
     <string name="summary_room_database">Room は SQLite 上にオブジェクトマッピングレイヤーを提供する永続化ライブラリです。この例ではメモを保存して表示する方法を示します。</string>
+
+    <string name="layouts">レイアウトとビュー</string>
+
+    <string name="linear_layout">リニアレイアウト</string>
+
+    <string name="vertical">縦</string>
+    <string name="horizontal">横</string>
+    <string name="layout_preview">レイアウトのプレビュー</string>
+    <string name="no_java_code_needed">このアクティビティには Java コードは不要です。</string>
+
+    <string name="relative_layout">相対レイアウト</string>
+
+    <string name="table_layout">テーブルレイアウト</string>
+
+    <string name="grid_view">グリッドビュー</string>
+
+    <string name="image_view">イメージビュー</string>
+
+    <string name="web_view">Webビュー</string>
+
+    <string name="buttons_and_switches">ボタンとスイッチ</string>
+    <string name="buttons">ボタン</string>
+    <string name="button">ボタン</string>
+    <string name="button_normal">ボタン1（標準）</string>
+    <string name="button_outlined">ボタン2（アウトライン）</string>
+    <string name="button_elevated">ボタン3（エレベーテッド）</string>
+    <string name="button_normal_icon">ボタン4（標準アイコン）</string>
+    <string name="button_outlined_icon">ボタン5（アウトラインアイコン）</string>
+    <string name="button_elevated_icon">ボタン6（エレベーテッドアイコン）</string>
+    <string name="extended_floating_button_primary">拡張フローティングボタン1（プライマリ）</string>
+    <string name="extended_floating_button_secondary">拡張フローティングボタン2（セカンダリ）</string>
+    <string name="extended_floating_button_surface">拡張フローティングボタン3（サーフェス）</string>
+    <string name="extended_floating_button_tertiary">拡張フローティングボタン4（ターシャリ）</string>
+    <string name="extended_floating_button_primary_icon">拡張フローティングボタン5（プライマリアイコン）</string>
+    <string name="extended_floating_button_secondary_icon">拡張フローティングボタン6（セカンダリアイコン）</string>
+    <string name="extended_floating_button_surface_icon">拡張フローティングボタン7（サーフェスアイコン）</string>
+    <string name="extended_floating_button_tertiary_icon">拡張フローティングボタン8（ターシャリアイコン）</string>
+    <string name="floating_button_primary_icon">フローティングボタン1（プライマリ）</string>
+    <string name="floating_button_secondary_icon">フローティングボタン2（セカンダリ）</string>
+    <string name="floating_button_surface_icon">フローティングボタン3（サーフェス）</string>
+    <string name="floating_button_tertiary_icon">フローティングボタン4（ターシャリ）</string>
+    <string name="same_code_buttons">すべての種類のボタンにこの Java コードを使用します。</string>
 </resources>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -148,4 +148,46 @@
     <string name="add_note">Dodaj notatkę</string>
     <string name="summary_preference_android_studio_room_database">Przechowuj proste notatki za pomocą Room, warstwy abstrakcji nad SQLite.</string>
     <string name="summary_room_database">Room to biblioteka trwałości, która zapewnia warstwę mapowania obiektów na SQLite. Ten przykład pokazuje, jak zapisywać i wyświetlać notatki.</string>
+
+    <string name="layouts">Układy i widoki</string>
+
+    <string name="linear_layout">Układ liniowy</string>
+
+    <string name="vertical">Pionowy</string>
+    <string name="horizontal">Poziomy</string>
+    <string name="layout_preview">Podgląd układu</string>
+    <string name="no_java_code_needed">Do tej aktywności nie jest wymagany kod Java.</string>
+
+    <string name="relative_layout">Układ względny</string>
+
+    <string name="table_layout">Układ tabelaryczny</string>
+
+    <string name="grid_view">Widok siatki</string>
+
+    <string name="image_view">Widok obrazu</string>
+
+    <string name="web_view">Widok internetowy</string>
+
+    <string name="buttons_and_switches">Przyciski i przełączniki</string>
+    <string name="buttons">Przyciski</string>
+    <string name="button">Przycisk</string>
+    <string name="button_normal">Przycisk 1 (standardowy)</string>
+    <string name="button_outlined">Przycisk 2 (z obramowaniem)</string>
+    <string name="button_elevated">Przycisk 3 (uniesiony)</string>
+    <string name="button_normal_icon">Przycisk 4 (standardowy z ikoną)</string>
+    <string name="button_outlined_icon">Przycisk 5 (z obramowaniem i ikoną)</string>
+    <string name="button_elevated_icon">Przycisk 6 (uniesiony z ikoną)</string>
+    <string name="extended_floating_button_primary">Rozszerzony przycisk pływający 1 (podstawowy)</string>
+    <string name="extended_floating_button_secondary">Rozszerzony przycisk pływający 2 (drugorzędny)</string>
+    <string name="extended_floating_button_surface">Rozszerzony przycisk pływający 3 (powierzchniowy)</string>
+    <string name="extended_floating_button_tertiary">Rozszerzony przycisk pływający 4 (trzeciorzędny)</string>
+    <string name="extended_floating_button_primary_icon">Rozszerzony przycisk pływający 5 (ikona podstawowa)</string>
+    <string name="extended_floating_button_secondary_icon">Rozszerzony przycisk pływający 6 (ikona drugorzędna)</string>
+    <string name="extended_floating_button_surface_icon">Rozszerzony przycisk pływający 7 (ikona powierzchniowa)</string>
+    <string name="extended_floating_button_tertiary_icon">Rozszerzony przycisk pływający 8 (ikona trzeciorzędna)</string>
+    <string name="floating_button_primary_icon">Przycisk pływający 1 (podstawowy)</string>
+    <string name="floating_button_secondary_icon">Przycisk pływający 2 (drugorzędny)</string>
+    <string name="floating_button_surface_icon">Przycisk pływający 3 (powierzchniowy)</string>
+    <string name="floating_button_tertiary_icon">Przycisk pływający 4 (trzeciorzędny)</string>
+    <string name="same_code_buttons">Użyj tego kodu Java dla wszystkich typów przycisków.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add Italian translations for layout and button examples
- add Hungarian translations for layout and button examples
- add Japanese translations for layout and button examples
- add Polish translations for layout and button examples

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b86bd1eb24832d9274a1fd5bfaaeef