### PR TITLE
chore: upgrade retrofit to 3.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ codeview = "1.3.9"
 hilt = "2.57.1"
 room = "2.7.2"
 glide = "5.0.4"
-retrofit = "2.11.0"
+retrofit = "3.0.0"
 
 [libraries]
 aboutlibraries = { module = "com.mikepenz:aboutlibraries", version.ref = "aboutlibraries" }


### PR DESCRIPTION
## Summary
- update retrofit to 3.0.0

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a6dd6718832d8903c6db39c5671b