### PR TITLE
Fix interpolator XML syntax

### DIFF
--- a/app/src/main/res/interpolator/fragment_spring.xml
+++ b/app/src/main/res/interpolator/fragment_spring.xml
@@ -1,3 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <overshootInterpolator xmlns:android="http://schemas.android.com/apk/res/android"
-    android:tension="1.0"/>
+    android:tension="1.0">
+</overshootInterpolator>
+


### PR DESCRIPTION
## Summary
- close overshoot interpolator tag in fragment spring resource

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8adebf780832d9be50acd3bb3f350