### PR TITLE
refactor: update strings and add daily tips

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -430,6 +430,8 @@
     <string name="daily_tip_hilt">ادمج Hilt لحقن التبعيات.</string>
     <string name="daily_tip_unit_tests">اكتب اختبارات الوحدة باستخدام JUnit و Espresso.</string>
     <string name="daily_tip_mvvm">اتبع بنية MVVM لكود قابل للصيانة.</string>
+    <string name="daily_tip_accessibility">صمّم لإمكانية الوصول باستخدام أوصاف المحتوى وتباين مناسب.</string>
+    <string name="daily_tip_battery_optimization">قلّل العمل الخلفي غير الضروري لتحسين عمر البطارية.</string>
     <string name="tip_of_the_day">نصيحة اليوم</string>
     <string name="quiz_title">اختبار</string>
     <string name="next_question">السؤال التالي</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -458,6 +458,8 @@
     <string name="daily_tip_hilt">Интегрирай Хилт за инжектиране на зависимост.</string>
     <string name="daily_tip_unit_tests">Пиши тестове с JUnit и Espresso.</string>
     <string name="daily_tip_mvvm">Следвайте MVVM архитектурата за поддържане на код.</string>
+    <string name="daily_tip_accessibility">Проектирайте за достъпност с описания на съдържанието и правилен контраст.</string>
+    <string name="daily_tip_battery_optimization">Намалете ненужната работа във фонов режим, за да подобрите живота на батерията.</string>
     <string name="tip_of_the_day">Съвет на деня</string>
     <string name="quiz_title">Тест</string>
     <string name="next_question">Следващ въпрос</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -458,6 +458,8 @@
     <string name="daily_tip_hilt">নির্ভরতার ইঞ্জেকশনের জন্য সমন্বিত হাইট।</string>
     <string name="daily_tip_unit_tests">JUN এবং এসপ্রেসোতে ইউনিট পরীক্ষা করো।</string>
     <string name="daily_tip_mvvm">যোগ্য কোডের জন্য এমভিএম স্থাপত্য অনুসরণ করুন।</string>
+    <string name="daily_tip_accessibility">কন্টেন্ট বর্ণনা এবং সঠিক কনট্রাস্ট দিয়ে অ্যাক্সেসিবিলিটির জন্য নকশা করুন।</string>
+    <string name="daily_tip_battery_optimization">অপ্রয়োজনীয় ব্যাকগ্রাউন্ড কাজ কমিয়ে ব্যাটারির স্থায়িত্ব বাড়ান।</string>
     <string name="tip_of_the_day">আজকের উপদেশ</string>
     <string name="quiz_title">কুইজ</string>
     <string name="next_question">পরবর্তী প্রশ্ন</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -458,6 +458,8 @@
     <string name="daily_tip_hilt">Integrieren Sie Hilt für Abhängigkeitsinjektion.</string>
     <string name="daily_tip_unit_tests">Schreibeinheitstests mit JUnit und Espresso.</string>
     <string name="daily_tip_mvvm">Folgen Sie der MVVM-Architektur für den Aufrechterhaltungscode.</string>
+    <string name="daily_tip_accessibility">Entwickle barrierefrei mit Inhaltsbeschreibungen und ausreichendem Kontrast.</string>
+    <string name="daily_tip_battery_optimization">Reduziere unnötige Hintergrundarbeit, um die Akkulaufzeit zu verbessern.</string>
     <string name="tip_of_the_day">Tipp des Tages</string>
     <string name="quiz_title">Quiz</string>
     <string name="next_question">Nächste Frage</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -458,6 +458,8 @@
     <string name="daily_tip_hilt">Integrar Hilt para la inyección de dependencia.</string>
     <string name="daily_tip_unit_tests">Escribe pruebas de unidad con JUnit y Espresso.</string>
     <string name="daily_tip_mvvm">Siga la arquitectura MVVM para mantener código.</string>
+    <string name="daily_tip_accessibility">Diseña para la accesibilidad con descripciones de contenido y contraste adecuado.</string>
+    <string name="daily_tip_battery_optimization">Reduce el trabajo en segundo plano innecesario para mejorar la duración de la batería.</string>
     <string name="tip_of_the_day">Consejo del día</string>
     <string name="quiz_title">Cuestionario</string>
     <string name="next_question">Siguiente pregunta</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -430,6 +430,8 @@
     <string name="daily_tip_hilt">Integra Hilt para la inyección de dependencias.</string>
     <string name="daily_tip_unit_tests">Escribe pruebas unitarias con JUnit y Espresso.</string>
     <string name="daily_tip_mvvm">Sigue la arquitectura MVVM para un código mantenible.</string>
+    <string name="daily_tip_accessibility">Diseña para la accesibilidad con descripciones de contenido y contraste adecuado.</string>
+    <string name="daily_tip_battery_optimization">Reduce el trabajo en segundo plano innecesario para mejorar la duración de la batería.</string>
     <string name="tip_of_the_day">Consejo del día</string>
     <string name="quiz_title">Cuestionario</string>
     <string name="next_question">Siguiente pregunta</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -430,6 +430,8 @@
     <string name="daily_tip_hilt">I-integrate ang Hilt para sa dependency injection.</string>
     <string name="daily_tip_unit_tests">Sumulat ng mga unit test gamit ang JUnit at Espresso.</string>
     <string name="daily_tip_mvvm">Sundin ang arkitektura ng MVVM para sa code na madaling i-maintain.</string>
+    <string name="daily_tip_accessibility">Magdisenyo para maging accessible gamit ang mga paglalarawan ng nilalaman at tamang contrast.</string>
+    <string name="daily_tip_battery_optimization">Bawasan ang hindi kinakailangang gawa sa background upang mapahaba ang buhay ng baterya.</string>
     <string name="tip_of_the_day">Tip ng Araw</string>
     <string name="quiz_title">Pagsusulit</string>
     <string name="next_question">Susunod na Tanong</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -458,6 +458,8 @@
     <string name="daily_tip_hilt">Intégrer Hilt pour injection de dépendance.</string>
     <string name="daily_tip_unit_tests">Écrire des tests unitaires avec Junit et Espresso.</string>
     <string name="daily_tip_mvvm">Suivez l\'architecture MVVM pour maintenir le code.</string>
+    <string name="daily_tip_accessibility">Concevez en tenant compte de l\'accessibilité avec des descriptions de contenu et un contraste adéquat.</string>
+    <string name="daily_tip_battery_optimization">Réduisez le travail en arrière-plan inutile pour améliorer l\'autonomie de la batterie.</string>
     <string name="tip_of_the_day">Astuce du jour</string>
     <string name="quiz_title">Quiz</string>
     <string name="next_question">Question suivante</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -459,6 +459,8 @@
     <string name="daily_tip_hilt">निर्भरता इंजेक्शन के लिए हिल्ट को एकीकृत करें।</string>
     <string name="daily_tip_unit_tests">JUnit and Espresso के साथ यूनिट परीक्षण लिखें।</string>
     <string name="daily_tip_mvvm">रखरखाव योग्य कोड के लिए MVVM वास्तुकला का पालन करें।</string>
+    <string name="daily_tip_accessibility">सामग्री विवरण और उचित कॉन्ट्रास्ट के साथ पहुँचनीयता के लिए डिज़ाइन करें।</string>
+    <string name="daily_tip_battery_optimization">बैटरी जीवन बढ़ाने के लिए अनावश्यक पृष्ठभूमि कार्य को कम करें।</string>
     <string name="tip_of_the_day">दिन का सुझाव</string>
     <string name="quiz_title">प्रश्नोत्तरी</string>
     <string name="next_question">अगला प्रश्न</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -477,6 +477,8 @@
     <string name="daily_tip_hilt">Integráld a Hiltet a függőséginjekcióhoz.</string>
     <string name="daily_tip_unit_tests">Írj egységteszteket JUnittal és Espresso-val.</string>
     <string name="daily_tip_mvvm">Kövesd az MVVM architektúrát a karbantartható kódért.</string>
+    <string name="daily_tip_accessibility">Tervezzen az akadálymentesség érdekében tartalmi leírásokkal és megfelelő kontraszttal.</string>
+    <string name="daily_tip_battery_optimization">Csökkentse a felesleges háttérmunkát az akkumulátor élettartamának javítása érdekében.</string>
     <string name="tip_of_the_day">A nap tippje</string>
     <string name="quiz_title">Kvíz</string>
     <string name="next_question">Következő kérdés</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -458,6 +458,8 @@
     <string name="daily_tip_hilt">Integrasikan Hilt untuk injeksi ketergantungan.</string>
     <string name="daily_tip_unit_tests">Tes unit tulis dengan JUnit dan Espresso.</string>
     <string name="daily_tip_mvvm">Ikuti arsitektur MVVM untuk kode yang dapat dipertahankan.</string>
+    <string name="daily_tip_accessibility">Rancang dengan aksesibilitas menggunakan deskripsi konten dan kontras yang tepat.</string>
+    <string name="daily_tip_battery_optimization">Kurangi pekerjaan latar belakang yang tidak perlu untuk meningkatkan daya tahan baterai.</string>
     <string name="tip_of_the_day">Tip Hari</string>
     <string name="quiz_title">Kuis</string>
     <string name="next_question">Pertanyaan Selanjutnya</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -471,7 +471,7 @@
     <string name="daily_tip_livedata_viewmodel">Sfrutta LiveData e ViewModel per UI reattive.</string>
     <string name="daily_tip_workmanager">Usa WorkManager per attività in background affidabili.</string>
     <string name="daily_tip_github_actions">Utilizza GitHub Actions per controlli di build automatizzati.</string>
-    <string name="daily_tip_emulator_screen_sizes">Testa la tua app su diverse dimensioni di schermo con l\'emulatore.</string>
+    <string name="daily_tip_emulator_screen_sizes">Testa la tua app su diverse dimensioni di schermo con l'emulatore.</string>
     <string name="daily_tip_update_dependencies">Mantieni aggiornate le dipendenze per le ultime funzionalità e correzioni.</string>
     <string name="daily_tip_kotlin_coroutines">Sfrutta le coroutine di Kotlin per operazioni asincrone.</string>
     <string name="daily_tip_hilt">Integra Hilt per l\'iniezione delle dipendenze.</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -477,6 +477,8 @@
     <string name="daily_tip_hilt">Integra Hilt per l\'iniezione delle dipendenze.</string>
     <string name="daily_tip_unit_tests">Scrivi test unitari con JUnit ed Espresso.</string>
     <string name="daily_tip_mvvm">Segui l\'architettura MVVM per un codice manutenibile.</string>
+    <string name="daily_tip_accessibility">Progetta per l'accessibilità con descrizioni dei contenuti e contrasto adeguato.</string>
+    <string name="daily_tip_battery_optimization">Riduci il lavoro in background non necessario per migliorare la durata della batteria.</string>
     <string name="tip_of_the_day">Suggerimento del giorno</string>
     <string name="quiz_title">Quiz</string>
     <string name="next_question">Prossima domanda</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -471,13 +471,13 @@
     <string name="daily_tip_livedata_viewmodel">Sfrutta LiveData e ViewModel per UI reattive.</string>
     <string name="daily_tip_workmanager">Usa WorkManager per attività in background affidabili.</string>
     <string name="daily_tip_github_actions">Utilizza GitHub Actions per controlli di build automatizzati.</string>
-    <string name="daily_tip_emulator_screen_sizes">Testa la tua app su diverse dimensioni di schermo con l'emulatore.</string>
+    <string name="daily_tip_emulator_screen_sizes">Testa la tua app su diverse dimensioni di schermo con l\'emulatore.</string>
     <string name="daily_tip_update_dependencies">Mantieni aggiornate le dipendenze per le ultime funzionalità e correzioni.</string>
     <string name="daily_tip_kotlin_coroutines">Sfrutta le coroutine di Kotlin per operazioni asincrone.</string>
     <string name="daily_tip_hilt">Integra Hilt per l\'iniezione delle dipendenze.</string>
     <string name="daily_tip_unit_tests">Scrivi test unitari con JUnit ed Espresso.</string>
     <string name="daily_tip_mvvm">Segui l\'architettura MVVM per un codice manutenibile.</string>
-    <string name="daily_tip_accessibility">Progetta per l'accessibilità con descrizioni dei contenuti e contrasto adeguato.</string>
+    <string name="daily_tip_accessibility">Progetta per l\'accessibilità con descrizioni dei contenuti e contrasto adeguato.</string>
     <string name="daily_tip_battery_optimization">Riduci il lavoro in background non necessario per migliorare la durata della batteria.</string>
     <string name="tip_of_the_day">Suggerimento del giorno</string>
     <string name="quiz_title">Quiz</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -477,6 +477,8 @@
     <string name="daily_tip_hilt">依存性注入には Hilt を統合。</string>
     <string name="daily_tip_unit_tests">JUnit と Espresso でユニットテストを書く。</string>
     <string name="daily_tip_mvvm">保守性の高いコードのために MVVM アーキテクチャに従う。</string>
+    <string name="daily_tip_accessibility">コンテンツの説明と適切なコントラストでアクセシビリティに配慮してデザインしましょう。</string>
+    <string name="daily_tip_battery_optimization">不要なバックグラウンド作業を減らしてバッテリー寿命を伸ばしましょう。</string>
     <string name="tip_of_the_day">今日のヒント</string>
     <string name="quiz_title">クイズ</string>
     <string name="next_question">次の質問</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -430,6 +430,8 @@
     <string name="daily_tip_hilt">종속성 주입을 위해 Hilt를 통합하세요.</string>
     <string name="daily_tip_unit_tests">JUnit과 Espresso로 단위 테스트를 작성하세요.</string>
     <string name="daily_tip_mvvm">유지보수가 용이한 코드를 위해 MVVM 아키텍처를 따르세요.</string>
+    <string name="daily_tip_accessibility">콘텐츠 설명과 적절한 대비로 접근성을 고려해 디자인하세요.</string>
+    <string name="daily_tip_battery_optimization">불필요한 백그라운드 작업을 줄여 배터리 수명을 향상시키세요.</string>
     <string name="tip_of_the_day">오늘의 팁</string>
     <string name="quiz_title">퀴즈</string>
     <string name="next_question">다음 질문</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -477,6 +477,8 @@
     <string name="daily_tip_hilt">Zintegruj Hilt do wstrzykiwania zależności.</string>
     <string name="daily_tip_unit_tests">Pisz testy jednostkowe za pomocą JUnit i Espresso.</string>
     <string name="daily_tip_mvvm">Stosuj architekturę MVVM dla łatwego w utrzymaniu kodu.</string>
+    <string name="daily_tip_accessibility">Projektuj z myślą o dostępności, używając opisów treści i odpowiedniego kontrastu.</string>
+    <string name="daily_tip_battery_optimization">Ogranicz zbędną pracę w tle, aby wydłużyć czas pracy baterii.</string>
     <string name="tip_of_the_day">Porada dnia</string>
     <string name="quiz_title">Quiz</string>
     <string name="next_question">Następne pytanie</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -430,6 +430,8 @@
     <string name="daily_tip_hilt">Integre o Hilt para injeção de dependência.</string>
     <string name="daily_tip_unit_tests">Escreva testes unitários com JUnit e Espresso.</string>
     <string name="daily_tip_mvvm">Siga a arquitetura MVVM para um código de fácil manutenção.</string>
+    <string name="daily_tip_accessibility">Projete com acessibilidade usando descrições de conteúdo e contraste adequado.</string>
+    <string name="daily_tip_battery_optimization">Reduza o trabalho em segundo plano desnecessário para melhorar a duração da bateria.</string>
     <string name="tip_of_the_day">Dica do Dia</string>
     <string name="quiz_title">Quiz</string>
     <string name="next_question">Próxima pergunta</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -466,6 +466,8 @@
     <string name="daily_tip_hilt">Integraţi Hilt pentru injectarea dependenţei.</string>
     <string name="daily_tip_unit_tests">Scrieţi teste de unitate cu JUnit şi Espresso.</string>
     <string name="daily_tip_mvvm">Urmăriți arhitectura MVVM pentru un cod durabil.</string>
+    <string name="daily_tip_accessibility">Proiectează pentru accesibilitate cu descrieri de conținut și contrast corespunzător.</string>
+    <string name="daily_tip_battery_optimization">Reduceți munca de fundal inutilă pentru a îmbunătăți durata bateriei.</string>
     <string name="tip_of_the_day">Sfat al zilei</string>
     <string name="quiz_title">Chestionar</string>
     <string name="next_question">Întrebarea următoare</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -458,6 +458,8 @@
     <string name="daily_tip_hilt">Интегрируйте Hilt для инъекций зависимости.</string>
     <string name="daily_tip_unit_tests">Пишите единичные тесты с JUnit и Espresso.</string>
     <string name="daily_tip_mvvm">Следуйте архитектуре MVVM для поддерживающего кода.</string>
+    <string name="daily_tip_accessibility">Проектируйте с учетом доступности, используя описания содержимого и правильный контраст.</string>
+    <string name="daily_tip_battery_optimization">Сократите ненужную фоновую работу, чтобы увеличить время работы батареи.</string>
     <string name="tip_of_the_day">День Победы</string>
     <string name="quiz_title">Викторина</string>
     <string name="next_question">Следующий вопрос</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -430,6 +430,8 @@
     <string name="daily_tip_hilt">Integrera Hilt för beroendeinjektion.</string>
     <string name="daily_tip_unit_tests">Skriv enhetstester med JUnit och Espresso.</string>
     <string name="daily_tip_mvvm">Följ MVVM-arkitekturen för underhållbar kod.</string>
+    <string name="daily_tip_accessibility">Designa för tillgänglighet med innehållsbeskrivningar och rätt kontrast.</string>
+    <string name="daily_tip_battery_optimization">Minska onödigt bakgrundsarbete för att förbättra batteritiden.</string>
     <string name="tip_of_the_day">Dagens tips</string>
     <string name="quiz_title">Quiz</string>
     <string name="next_question">Nästa fråga</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -432,6 +432,8 @@
     <string name="daily_tip_hilt">ผสานรวม Hilt สำหรับการฉีดการพึ่งพา</string>
     <string name="daily_tip_unit_tests">เขียนการทดสอบหน่วยด้วย JUnit และ Espresso</string>
     <string name="daily_tip_mvvm">ปฏิบัติตามสถาปัตยกรรม MVVM เพื่อโค้ดที่บำรุงรักษาง่าย</string>
+    <string name="daily_tip_accessibility">ออกแบบโดยคำนึงถึงการเข้าถึงด้วยคำอธิบายเนื้อหาและความคมชัดที่เหมาะสม.</string>
+    <string name="daily_tip_battery_optimization">ลดงานเบื้องหลังที่ไม่จำเป็นเพื่อยืดอายุการใช้งานแบตเตอรี่.</string>
     <string name="tip_of_the_day">เคล็ดลับประจำวัน</string>
     <string name="quiz_title">แบบทดสอบ</string>
     <string name="next_question">คำถามถัดไป</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -430,6 +430,8 @@
     <string name="daily_tip_hilt">Bağımlılık enjeksiyonu için Hilt\'i entegre edin.</string>
     <string name="daily_tip_unit_tests">JUnit ve Espresso ile birim testleri yazın.</string>
     <string name="daily_tip_mvvm">Bakımı kolay kod için MVVM mimarisini takip edin.</string>
+    <string name="daily_tip_accessibility">İçerik açıklamaları ve uygun kontrastla erişilebilirlik için tasarlayın.</string>
+    <string name="daily_tip_battery_optimization">Pil ömrünü artırmak için gereksiz arka plan çalışmalarını azaltın.</string>
     <string name="tip_of_the_day">Günün İpucu</string>
     <string name="quiz_title">Test</string>
     <string name="next_question">Sonraki Soru</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -430,6 +430,8 @@
     <string name="daily_tip_hilt">Інтегруйте Hilt для впровадження залежностей.</string>
     <string name="daily_tip_unit_tests">Пишіть юніт-тести з JUnit та Espresso.</string>
     <string name="daily_tip_mvvm">Дотримуйтесь архітектури MVVM для коду, який легко підтримувати.</string>
+    <string name="daily_tip_accessibility">Проєктуйте з урахуванням доступності, використовуючи описи вмісту та належний контраст.</string>
+    <string name="daily_tip_battery_optimization">Зменшуйте непотрібну фонову роботу, щоб покращити час роботи акумулятора.</string>
     <string name="tip_of_the_day">Порада дня</string>
     <string name="quiz_title">Вікторина</string>
     <string name="next_question">Наступне запитання</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -430,6 +430,8 @@
     <string name="daily_tip_hilt">انحصار انجیکشن کے لیے Hilt کو مربوط کریں۔</string>
     <string name="daily_tip_unit_tests">JUnit اور Espresso کے ساتھ یونٹ ٹیسٹ لکھیں۔</string>
     <string name="daily_tip_mvvm">قابل دیکھ بھال کوڈ کے لیے MVVM آرکیٹیکچر کی پیروی کریں۔</string>
+    <string name="daily_tip_accessibility">رسائی کے لیے مواد کی وضاحتوں اور مناسب کنٹراسٹ کے ساتھ ڈیزائن کریں۔</string>
+    <string name="daily_tip_battery_optimization">بیٹری کی زندگی بہتر بنانے کے لیے غیر ضروری پس منظر کا کام کم کریں۔</string>
     <string name="tip_of_the_day">آج کی ٹپ</string>
     <string name="quiz_title">کوئز</string>
     <string name="next_question">اگلا سوال</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -430,6 +430,8 @@
     <string name="daily_tip_hilt">Tích hợp Hilt để tiêm phụ thuộc.</string>
     <string name="daily_tip_unit_tests">Viết các bài kiểm tra đơn vị với JUnit và Espresso.</string>
     <string name="daily_tip_mvvm">Tuân theo kiến trúc MVVM để có mã có thể bảo trì.</string>
+    <string name="daily_tip_accessibility">Thiết kế có tính đến khả năng tiếp cận với mô tả nội dung và độ tương phản phù hợp.</string>
+    <string name="daily_tip_battery_optimization">Giảm công việc nền không cần thiết để cải thiện thời lượng pin.</string>
     <string name="tip_of_the_day">Mẹo trong ngày</string>
     <string name="quiz_title">Câu đố</string>
     <string name="next_question">Câu hỏi tiếp theo</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -430,6 +430,8 @@
     <string name="daily_tip_hilt">整合 Hilt 進行依賴注入。</string>
     <string name="daily_tip_unit_tests">使用 JUnit 和 Espresso 編寫單元測試。</string>
     <string name="daily_tip_mvvm">遵循 MVVM 架構以獲得可維護的程式碼。</string>
+    <string name="daily_tip_accessibility">使用內容描述和適當的對比來設計無障礙性。</string>
+    <string name="daily_tip_battery_optimization">減少不必要的背景作業以改善電池續航。</string>
     <string name="tip_of_the_day">今日提示</string>
     <string name="quiz_title">小測驗</string>
     <string name="next_question">下一題</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -127,5 +127,7 @@
         <item>@string/daily_tip_hilt</item>
         <item>@string/daily_tip_unit_tests</item>
         <item>@string/daily_tip_mvvm</item>
+        <item>@string/daily_tip_accessibility</item>
+        <item>@string/daily_tip_battery_optimization</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,9 +2,9 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="image_view_preview_desc">Image view preview</string>
     <string name="app_short_description">Learn how to make simple Java apps in Android Studio. 📱</string>
-    <string name="notification_update_title">A new update is available.</string>
+    <string name="notification_update_title">A new update is available</string>
     <string name="summary_notification_update">A new version of the app is available. Tap to update.</string>
-    <string name="notification_last_time_used_title">It\'s been a while.</string>
+    <string name="notification_last_time_used_title">It\'s been a while</string>
     <string name="summary_notification_last_time_used">It\'s been a while—learn something new about Android.</string>
 
     <string name="menu">Menu</string>
@@ -52,7 +52,7 @@
     <string name="add_to_favorites">Add to favorites</string>
     <string name="file_inspect">Inspect current file with current profile</string>
     <string name="quick_switch_theme">Quick switch theme</string>
-    <string name="open_settings">Open settings dialogue</string>
+    <string name="open_settings">Open settings dialog</string>
     <string name="open_project">Open project structure dialog</string>
     <string name="switch_tabs">Switch between tabs and tool window</string>
     <string name="refactoring">Refactoring</string>
@@ -154,7 +154,7 @@
     <string name="vertical">Vertical</string>
     <string name="horizontal">Horizontal</string>
     <string name="layout_preview">Layout preview</string>
-    <string name="no_java_code_needed">No Java code required for this activity.</string>
+    <string name="no_java_code_needed">No Java code required for this activity</string>
 
     <string name="relative_layout">Relative layout</string>
 
@@ -220,9 +220,9 @@
     <string name="reset">Reset</string>
     <string name="text_boxes">Text boxes</string>
     <string name="textbox">Text box</string>
-    <string name="print_text">Print text.</string>
+    <string name="print_text">Print text</string>
     <string name="password_box">Password box</string>
-    <string name="password_show">Show password.</string>
+    <string name="password_show">Show password</string>
     <string name="alerts">Alerts</string>
     <string name="alert_dialog">Alert dialog</string>
     <string name="show_dialog">Show alert dialog</string>
@@ -234,8 +234,8 @@
     <string name="tooltips">Tooltips</string>
     <string name="reviews">Reviews</string>
     <string name="rating_bar">Rating bar</string>
-    <string name="rate_us">Rate the app.</string>
-    <string name="stars">%1$.1f stars.</string>
+    <string name="rate_us">Rate the app</string>
+    <string name="stars">%1$.1f stars</string>
     <string name="in_app_review">In-app reviews</string>
     <string name="progress_bars">Progress bars</string>
     <string name="progress_bar">Progress bar</string>
@@ -330,7 +330,7 @@
     <string name="summary_preference_faq_6">If you have a question or problem with Android Studio Tutorials: Java Edition, contact support through the app\'s support page or by email at d4rk7355608@gmail.com. The support team will work to resolve any issues you experience.</string>
     <string name="summary_preference_faq_7">You can disable Firebase analytics and crashlytics by going to the settings menu in the app and toggle the switch for these features.</string>
     <string name="summary_preference_faq_8">You can check for updates to Android Studio Tutorials: Java Edition by going to the settings menu in the app and selecting the \"Check for updates\" option.</string>
-    <string name="summary_preference_faq_9">ou can support the development of Android Studio Tutorials: Java Edition by leaving a positive review on the Google Play Store, sharing the app with friends and colleagues, and supporting the developers through the \"Share\" option in the settings menu.</string>
+    <string name="summary_preference_faq_9">You can support the development of Android Studio Tutorials: Java Edition by leaving a positive review on the Google Play Store, sharing the app with friends and colleagues, and supporting the developers through the \"Share\" option in the settings menu.</string>
     <string name="summary_preference_permissions_ad_id">Allows the app to retrieve and use the advertising identifier associated with the user\'s device, providing personalized ads, measuring ad effectiveness, and showing ads on Android 13 or later devices.</string>
     <string name="summary_preference_permissions_internet">Allows the app to establish an internet connection to send error reports or check for updates.</string>
     <string name="summary_preference_permissions_post_notifications">Allows the app to display notifications on the devices with Android 13 or later.</string>
@@ -453,6 +453,8 @@
     <string name="daily_tip_hilt">Integrate Hilt for dependency injection.</string>
     <string name="daily_tip_unit_tests">Write unit tests with JUnit and Espresso.</string>
     <string name="daily_tip_mvvm">Follow the MVVM architecture for maintainable code.</string>
+    <string name="daily_tip_accessibility">Design for accessibility with content descriptions and proper contrast.</string>
+    <string name="daily_tip_battery_optimization">Reduce unnecessary background work to improve battery life.</string>
     <string name="tip_of_the_day">Tip of the day</string>
     <string name="quiz_title">Quiz</string>
     <string name="next_question">Next question</string>

--- a/app/src/main/res/values/untranslatable_strings.xml
+++ b/app/src/main/res/values/untranslatable_strings.xml
@@ -24,7 +24,7 @@
     <string name="russian" translatable="false">Русский</string>
     <string name="spanish" translatable="false">Español</string>
     <string name="turkish" translatable="false">Türkçe</string>
-    <string name="swedish" translatable="false">Svenska</string>"
+    <string name="swedish" translatable="false">Svenska</string>
     <string name="ukrainian" translatable="false">Українська</string>
     <string name="traditional_chinese" translatable="false">中文</string>
     <string name="thai" translatable="false">ไทย</string>
@@ -49,11 +49,11 @@
 
 
     <string name="eula_title" translatable="false">EULA</string>
-    <string name="changelog" translatable="false">CHANGELOG</string>
-    <string name="loading_eula" translatable="false">>Loading EULA</string>
-    <string name="error_loading_eula" translatable="false">>Error loading EULA</string>
-    <string name="loading_changelog" translatable="false">>Loading changelog</string>
-    <string name="error_loading_changelog" translatable="false">>Error loading changelog</string>
+    <string name="changelog" translatable="false">Changelog</string>
+    <string name="loading_eula" translatable="false">Loading EULA</string>
+    <string name="error_loading_eula" translatable="false">Error loading EULA</string>
+    <string name="loading_changelog" translatable="false">Loading changelog</string>
+    <string name="error_loading_changelog" translatable="false">Error loading changelog</string>
 
     <string name="ad_banner_unit_id" translatable="false">ca-app-pub-5294151573817700/3821250346</string>
 </resources>


### PR DESCRIPTION
## Summary
- polish untranslatable strings and loading messages
- fix typos and trailing punctuation in UI strings
- introduce accessibility and battery tips and wire into daily tips list
- localize new daily tip strings across supported languages

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9533ca188832da0d5884d9a562700