### PR TITLE
Replace AdMob banners with native ads

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ads/managers/NativeAdLoader.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ads/managers/NativeAdLoader.java
@@ -1,0 +1,70 @@
+package com.d4rk.androidtutorials.java.ads.managers;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+
+import com.d4rk.androidtutorials.java.R;
+import com.google.android.gms.ads.AdLoader;
+import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.nativead.MediaView;
+import com.google.android.gms.ads.nativead.NativeAd;
+import com.google.android.gms.ads.nativead.NativeAdView;
+
+/**
+ * Helper class to load AdMob native ads into a container.
+ */
+public class NativeAdLoader {
+
+    public static void load(@NonNull Context context, @NonNull ViewGroup container) {
+        AdLoader adLoader = new AdLoader.Builder(context, context.getString(R.string.ad_banner_unit_id))
+                .forNativeAd(nativeAd -> {
+                    LayoutInflater inflater = LayoutInflater.from(context);
+                    NativeAdView adView = (NativeAdView) inflater.inflate(R.layout.native_ad, container, false);
+                    populateNativeAdView(nativeAd, adView);
+                    container.removeAllViews();
+                    container.addView(adView);
+                })
+                .build();
+        adLoader.loadAd(new AdRequest.Builder().build());
+    }
+
+    private static void populateNativeAdView(@NonNull NativeAd nativeAd, @NonNull NativeAdView adView) {
+        adView.setMediaView((MediaView) adView.findViewById(R.id.ad_media));
+        adView.setHeadlineView(adView.findViewById(R.id.ad_headline));
+        adView.setBodyView(adView.findViewById(R.id.ad_body));
+        adView.setCallToActionView(adView.findViewById(R.id.ad_call_to_action));
+        adView.setIconView(adView.findViewById(R.id.ad_app_icon));
+
+        ((TextView) adView.getHeadlineView()).setText(nativeAd.getHeadline());
+
+        if (nativeAd.getBody() == null) {
+            adView.getBodyView().setVisibility(View.GONE);
+        } else {
+            adView.getBodyView().setVisibility(View.VISIBLE);
+            ((TextView) adView.getBodyView()).setText(nativeAd.getBody());
+        }
+
+        if (nativeAd.getCallToAction() == null) {
+            adView.getCallToActionView().setVisibility(View.GONE);
+        } else {
+            adView.getCallToActionView().setVisibility(View.VISIBLE);
+            ((Button) adView.getCallToActionView()).setText(nativeAd.getCallToAction());
+        }
+
+        if (nativeAd.getIcon() == null) {
+            adView.getIconView().setVisibility(View.GONE);
+        } else {
+            ((ImageView) adView.getIconView()).setImageDrawable(nativeAd.getIcon().getDrawable());
+            adView.getIconView().setVisibility(View.VISIBLE);
+        }
+
+        adView.setNativeAd(nativeAd);
+    }
+}

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ads/views/NativeAdBannerView.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ads/views/NativeAdBannerView.java
@@ -1,0 +1,34 @@
+package com.d4rk.androidtutorials.java.ads.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.FrameLayout;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.gms.ads.AdRequest;
+import com.d4rk.androidtutorials.java.ads.managers.NativeAdLoader;
+
+/**
+ * Custom view that acts as a drop-in replacement for AdView and loads
+ * a native ad using {@link NativeAdLoader} when {@link #loadAd(AdRequest)} is called.
+ */
+public class NativeAdBannerView extends FrameLayout {
+
+    public NativeAdBannerView(@NonNull Context context) {
+        super(context);
+    }
+
+    public NativeAdBannerView(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public NativeAdBannerView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public void loadAd(AdRequest adRequest) {
+        NativeAdLoader.load(getContext(), this);
+    }
+}

--- a/app/src/main/res/layout/activity_android_history.xml
+++ b/app/src/main/res/layout/activity_android_history.xml
@@ -30,13 +30,11 @@
             app:layout_constraintTop_toBottomOf="@id/text_view_history"
             tools:ignore="VisualLintLongText" />
 
-        <com.google.android.gms.ads.AdView
+        <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
             android:id="@+id/ad_view"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="24dp"
-            app:adSize="MEDIUM_RECTANGLE"
-            app:adUnitId="@string/ad_banner_unit_id"
             app:layout_constraintTop_toBottomOf="@id/text_view_android_history" />
 
         <com.google.android.material.textview.MaterialTextView
@@ -59,13 +57,11 @@
             app:layout_constraintTop_toBottomOf="@id/text_view_features"
             tools:ignore="VisualLintLongText" />
 
-        <com.google.android.gms.ads.AdView
+        <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
             android:id="@+id/ad_view_bottom"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="24dp"
-            app:adSize="FULL_BANNER"
-            app:adUnitId="@string/ad_banner_unit_id"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/text_view_android_features" />

--- a/app/src/main/res/layout/activity_android_sdk.xml
+++ b/app/src/main/res/layout/activity_android_sdk.xml
@@ -22,13 +22,11 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:ignore="VisualLintLongText" />
 
-        <com.google.android.gms.ads.AdView
+        <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
             android:id="@+id/ad_view"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            app:adSize="MEDIUM_RECTANGLE"
-            app:adUnitId="@string/ad_banner_unit_id"
             app:layout_constraintTop_toBottomOf="@id/text_view_android_sdks_summary" />
 
         <com.google.android.material.textview.MaterialTextView
@@ -62,13 +60,11 @@
                 android:stretchColumns="0,1,2,3,4" />
         </com.google.android.material.card.MaterialCardView>
 
-        <com.google.android.gms.ads.AdView
+        <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
             android:id="@+id/ad_view_bottom"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            app:adSize="FULL_BANNER"
-            app:adUnitId="@string/ad_banner_unit_id"
             app:layout_constraintTop_toBottomOf="@id/card_view_table_layout" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </me.zhanghai.android.fastscroll.FastScrollScrollView>

--- a/app/src/main/res/layout/activity_android_start_project.xml
+++ b/app/src/main/res/layout/activity_android_start_project.xml
@@ -69,13 +69,11 @@
                     android:contentDescription="@string/im_step1_desc" />
             </com.google.android.material.card.MaterialCardView>
 
-            <com.google.android.gms.ads.AdView
+            <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
                 android:id="@+id/ad_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="24dp"
-                app:adSize="MEDIUM_RECTANGLE"
-                app:adUnitId="@string/ad_banner_unit_id"
                 app:layout_constraintTop_toBottomOf="@id/card_view_first_step" />
 
             <com.google.android.material.textview.MaterialTextView
@@ -168,13 +166,11 @@
                 app:lottie_rawRes="@raw/anim_programmer"
                 app:lottie_speed="0.5" />
 
-            <com.google.android.gms.ads.AdView
+            <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
                 android:id="@+id/ad_view_bottom"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_margin="24dp"
-                app:adSize="FULL_BANNER"
-                app:adUnitId="@string/ad_banner_unit_id"
                 app:layout_constraintTop_toBottomOf="@id/lottie_animation" />
         </androidx.constraintlayout.widget.ConstraintLayout>
     </me.zhanghai.android.fastscroll.FastScrollScrollView>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -24,7 +24,6 @@
         android:id="@+id/nav_rail"
         android:layout_width="wrap_content"
         android:layout_height="0dp"
-        android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/app_bar_layout"
         app:layout_constraintBottom_toTopOf="@+id/ad_container"
@@ -54,13 +53,11 @@
             android:layout_height="match_parent"
             android:background="@android:color/darker_gray" />
 
-        <com.google.android.gms.ads.AdView
+        <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
             android:id="@+id/ad_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:visibility="gone"
-            app:adSize="FULL_BANNER"
-            app:adUnitId="@string/ad_banner_unit_id" />
+/>
     </FrameLayout>
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
@@ -75,7 +72,6 @@
         android:id="@+id/progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:visibility="gone"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/activity_permissions_tutorial.xml
+++ b/app/src/main/res/layout/activity_permissions_tutorial.xml
@@ -18,13 +18,11 @@
             android:text="@string/summary_permissions"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <com.google.android.gms.ads.AdView
+        <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
             android:id="@+id/ad_view_large"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="24dp"
-            app:adSize="MEDIUM_RECTANGLE"
-            app:adUnitId="@string/ad_banner_unit_id"
             app:layout_constraintTop_toBottomOf="@id/text_view_permissions_beginning" />
 
         <com.google.android.material.textview.MaterialTextView
@@ -74,13 +72,11 @@
             app:layout_constraintTop_toBottomOf="@id/card_view_lottie_animation"
             tools:targetApi="26" />
 
-        <com.google.android.gms.ads.AdView
+        <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
             android:id="@+id/ad_view_bottom"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="24dp"
-            app:adSize="FULL_BANNER"
-            app:adUnitId="@string/ad_banner_unit_id"
             app:layout_constraintTop_toBottomOf="@id/button_more" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </me.zhanghai.android.fastscroll.FastScrollScrollView>

--- a/app/src/main/res/layout/activity_shortcuts.xml
+++ b/app/src/main/res/layout/activity_shortcuts.xml
@@ -28,12 +28,10 @@
         app:layout_constraintStart_toStartOf="parent"
         tools:targetApi="26" />
 
-    <com.google.android.gms.ads.AdView
+    <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
         android:id="@+id/ad_view_bottom"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        app:adSize="FULL_BANNER"
-        app:adUnitId="@string/ad_banner_unit_id"
         app:layout_constraintBottom_toBottomOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_shortcuts_build.xml
+++ b/app/src/main/res/layout/activity_shortcuts_build.xml
@@ -114,13 +114,11 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
     </me.zhanghai.android.fastscroll.FastScrollScrollView>
 
-    <com.google.android.gms.ads.AdView
+    <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
         android:id="@+id/ad_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        app:adSize="FULL_BANNER"
-        app:adUnitId="@string/ad_banner_unit_id"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/layout/activity_shortcuts_code.xml
+++ b/app/src/main/res/layout/activity_shortcuts_code.xml
@@ -273,13 +273,11 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
     </me.zhanghai.android.fastscroll.FastScrollScrollView>
 
-    <com.google.android.gms.ads.AdView
+    <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
         android:id="@+id/ad_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        app:adSize="FULL_BANNER"
-        app:adUnitId="@string/ad_banner_unit_id"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/layout/activity_shortcuts_debugging.xml
+++ b/app/src/main/res/layout/activity_shortcuts_debugging.xml
@@ -273,13 +273,11 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
     </me.zhanghai.android.fastscroll.FastScrollScrollView>
 
-    <com.google.android.gms.ads.AdView
+    <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
         android:id="@+id/ad_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        app:adSize="FULL_BANNER"
-        app:adUnitId="@string/ad_banner_unit_id"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/layout/activity_shortcuts_general.xml
+++ b/app/src/main/res/layout/activity_shortcuts_general.xml
@@ -250,13 +250,11 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
     </me.zhanghai.android.fastscroll.FastScrollScrollView>
 
-    <com.google.android.gms.ads.AdView
+    <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
         android:id="@+id/ad_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        app:adSize="FULL_BANNER"
-        app:adUnitId="@string/ad_banner_unit_id"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/layout/activity_shortcuts_navigation_and_searching.xml
+++ b/app/src/main/res/layout/activity_shortcuts_navigation_and_searching.xml
@@ -595,13 +595,11 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
     </me.zhanghai.android.fastscroll.FastScrollScrollView>
 
-    <com.google.android.gms.ads.AdView
+    <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
         android:id="@+id/ad_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        app:adSize="FULL_BANNER"
-        app:adUnitId="@string/ad_banner_unit_id"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/layout/activity_shortcuts_refractoring.xml
+++ b/app/src/main/res/layout/activity_shortcuts_refractoring.xml
@@ -273,13 +273,11 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
     </me.zhanghai.android.fastscroll.FastScrollScrollView>
 
-    <com.google.android.gms.ads.AdView
+    <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
         android:id="@+id/ad_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        app:adSize="FULL_BANNER"
-        app:adUnitId="@string/ad_banner_unit_id"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/layout/activity_shortcuts_version_control.xml
+++ b/app/src/main/res/layout/activity_shortcuts_version_control.xml
@@ -135,13 +135,11 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
     </me.zhanghai.android.fastscroll.FastScrollScrollView>
 
-    <com.google.android.gms.ads.AdView
+    <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
         android:id="@+id/ad_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        app:adSize="FULL_BANNER"
-        app:adUnitId="@string/ad_banner_unit_id"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/layout/activity_support.xml
+++ b/app/src/main/res/layout/activity_support.xml
@@ -120,14 +120,13 @@
                 app:layout_columnWeight="1"
                 app:layout_rowWeight="1" />
 
-            <com.google.android.gms.ads.AdView
+            <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
                 android:id="@+id/large_banner_ad"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
                 android:layout_marginBottom="16dp"
-                app:adSize="MEDIUM_RECTANGLE"
-                app:adUnitId="@string/ad_banner_unit_id" />
+/>
         </androidx.appcompat.widget.LinearLayoutCompat>
     </me.zhanghai.android.fastscroll.FastScrollScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_view_binding_tutorial.xml
+++ b/app/src/main/res/layout/activity_view_binding_tutorial.xml
@@ -40,12 +40,10 @@
             android:text="@string/summary_enable_binding"
             app:layout_constraintTop_toBottomOf="@id/bindingSetupText" />
 
-        <com.google.android.gms.ads.AdView
+        <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
             android:id="@+id/ad_view"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:adSize="MEDIUM_RECTANGLE"
-            app:adUnitId="@string/ad_banner_unit_id"
             app:layout_constraintTop_toBottomOf="@id/bindingInstructionText" />
 
         <com.google.android.material.card.MaterialCardView
@@ -153,13 +151,11 @@
             app:lottie_loop="false"
             app:lottie_rawRes="@raw/anim_jetpack" />
 
-        <com.google.android.gms.ads.AdView
+        <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
             android:id="@+id/ad_view_bottom"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="24dp"
-            app:adSize="FULL_BANNER"
-            app:adUnitId="@string/ad_banner_unit_id"
             app:layout_constraintTop_toBottomOf="@id/lottie_animation" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </me.zhanghai.android.fastscroll.FastScrollScrollView>

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <me.zhanghai.android.fastscroll.FastScrollScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:ads="http://schemas.android.com/apk/res-auto"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/scroll_view"
@@ -169,13 +168,11 @@
             </androidx.constraintlayout.widget.ConstraintLayout>
         </com.google.android.material.card.MaterialCardView>
 
-        <com.google.android.gms.ads.AdView
+        <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
             android:id="@+id/ad_view"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            ads:adSize="MEDIUM_RECTANGLE"
-            ads:adUnitId="@string/ad_banner_unit_id"
             app:layout_constraintTop_toBottomOf="@id/card_view_about" />
 
         <com.airbnb.lottie.LottieAnimationView

--- a/app/src/main/res/layout/fragment_buttons_layout.xml
+++ b/app/src/main/res/layout/fragment_buttons_layout.xml
@@ -262,12 +262,10 @@
         </me.zhanghai.android.fastscroll.FastScrollScrollView>
     </com.google.android.material.card.MaterialCardView>
 
-    <com.google.android.gms.ads.AdView
+    <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
         android:id="@+id/ad_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        app:adSize="FULL_BANNER"
-        app:adUnitId="@string/ad_banner_unit_id"
         app:layout_constraintBottom_toBottomOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_clock_layout.xml
+++ b/app/src/main/res/layout/fragment_clock_layout.xml
@@ -69,12 +69,10 @@
         </me.zhanghai.android.fastscroll.FastScrollScrollView>
     </com.google.android.material.card.MaterialCardView>
 
-    <com.google.android.gms.ads.AdView
+    <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
         android:id="@+id/ad_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        app:adSize="FULL_BANNER"
-        app:adUnitId="@string/ad_banner_unit_id"
         app:layout_constraintBottom_toBottomOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_code.xml
+++ b/app/src/main/res/layout/fragment_code.xml
@@ -26,13 +26,11 @@
         </me.zhanghai.android.fastscroll.FastScrollScrollView>
     </com.google.android.material.card.MaterialCardView>
 
-    <com.google.android.gms.ads.AdView
+    <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
         android:id="@+id/ad_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        app:adSize="FULL_BANNER"
-        app:adUnitId="@string/ad_banner_unit_id"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -143,14 +143,13 @@
                 </androidx.appcompat.widget.LinearLayoutCompat>
             </com.google.android.material.card.MaterialCardView>
 
-            <com.google.android.gms.ads.AdView
+            <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
                 android:id="@+id/large_banner_ad"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
                 android:layout_marginBottom="16dp"
-                app:adSize="MEDIUM_RECTANGLE"
-                app:adUnitId="@string/ad_banner_unit_id" />
+/>
 
             <androidx.appcompat.widget.LinearLayoutCompat
                 android:id="@+id/other_apps_section"
@@ -215,13 +214,12 @@
                 </androidx.appcompat.widget.LinearLayoutCompat>
             </com.google.android.material.card.MaterialCardView>
 
-            <com.google.android.gms.ads.AdView
+            <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
                 android:id="@+id/small_banner_ad"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
-                app:adSize="MEDIUM_RECTANGLE"
-                app:adUnitId="@string/ad_banner_unit_id" />
+/>
 
             <com.airbnb.lottie.LottieAnimationView
                 android:id="@+id/learningAnimation"

--- a/app/src/main/res/layout/fragment_layout.xml
+++ b/app/src/main/res/layout/fragment_layout.xml
@@ -26,13 +26,11 @@
         </me.zhanghai.android.fastscroll.FastScrollScrollView>
     </com.google.android.material.card.MaterialCardView>
 
-    <com.google.android.gms.ads.AdView
+    <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
         android:id="@+id/ad_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        app:adSize="FULL_BANNER"
-        app:adUnitId="@string/ad_banner_unit_id"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/layout/fragment_linear_layout_layout.xml
+++ b/app/src/main/res/layout/fragment_linear_layout_layout.xml
@@ -52,12 +52,10 @@
         </me.zhanghai.android.fastscroll.FastScrollScrollView>
     </com.google.android.material.card.MaterialCardView>
 
-    <com.google.android.gms.ads.AdView
+    <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
         android:id="@+id/ad_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        app:adSize="FULL_BANNER"
-        app:adUnitId="@string/ad_banner_unit_id"
         app:layout_constraintBottom_toBottomOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_no_code.xml
+++ b/app/src/main/res/layout/fragment_no_code.xml
@@ -23,12 +23,10 @@
             android:textAlignment="center" />
     </com.google.android.material.card.MaterialCardView>
 
-    <com.google.android.gms.ads.AdView
+    <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
         android:id="@+id/ad_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        app:adSize="FULL_BANNER"
-        app:adUnitId="@string/ad_banner_unit_id"
         app:layout_constraintBottom_toBottomOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_same_code.xml
+++ b/app/src/main/res/layout/fragment_same_code.xml
@@ -48,12 +48,10 @@
         </me.zhanghai.android.fastscroll.FastScrollScrollView>
     </com.google.android.material.card.MaterialCardView>
 
-    <com.google.android.gms.ads.AdView
+    <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
         android:id="@+id/ad_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="24dp"
-        app:adSize="FULL_BANNER"
-        app:adUnitId="@string/ad_banner_unit_id"
         app:layout_constraintBottom_toBottomOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/native_ad.xml
+++ b/app/src/main/res/layout/native_ad.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.gms.ads.nativead.NativeAdView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.google.android.material.card.MaterialCardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.CardView">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="8dp">
+
+            <com.google.android.gms.ads.nativead.MediaView
+                android:id="@+id/ad_media"
+                android:layout_width="match_parent"
+                android:layout_height="180dp"
+                android:visibility="gone" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <ImageView
+                    android:id="@+id/ad_app_icon"
+                    android:layout_width="40dp"
+                    android:layout_height="40dp"
+                    android:layout_marginEnd="8dp" />
+
+                <TextView
+                    android:id="@+id/ad_headline"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:textAppearance="@style/TextAppearance.Material3.TitleMedium" />
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/ad_body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:textAppearance="@style/TextAppearance.Material3.BodySmall" />
+
+            <Button
+                android:id="@+id/ad_call_to_action"
+                style="@style/Widget.Material3.Button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+</com.google.android.gms.ads.nativead.NativeAdView>


### PR DESCRIPTION
## Summary
- add `NativeAdLoader` to inflate and populate native ads
- introduce `NativeAdBannerView` as drop-in replacement for banner `AdView`
- swap all banner `AdView`s for `NativeAdBannerView` and add `native_ad` layout

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9eb1d7efc832d890885ffb0616e24