### PR TITLE
Fix native ad view handling

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ads/managers/NativeAdLoader.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ads/managers/NativeAdLoader.java
@@ -36,33 +36,56 @@ public class NativeAdLoader {
     }
 
     private static void populateNativeAdView(@NonNull NativeAd nativeAd, @NonNull NativeAdView adView) {
-        adView.setMediaView((MediaView) adView.findViewById(R.id.ad_media));
-        adView.setHeadlineView(adView.findViewById(R.id.ad_headline));
-        adView.setBodyView(adView.findViewById(R.id.ad_body));
-        adView.setCallToActionView(adView.findViewById(R.id.ad_call_to_action));
-        adView.setIconView(adView.findViewById(R.id.ad_app_icon));
+        MediaView mediaView = adView.findViewById(R.id.ad_media);
+        TextView headlineView = adView.findViewById(R.id.ad_headline);
+        TextView bodyView = adView.findViewById(R.id.ad_body);
+        Button callToActionView = adView.findViewById(R.id.ad_call_to_action);
+        ImageView iconView = adView.findViewById(R.id.ad_app_icon);
 
-        ((TextView) adView.getHeadlineView()).setText(nativeAd.getHeadline());
+        adView.setMediaView(mediaView);
+        adView.setHeadlineView(headlineView);
+        adView.setBodyView(bodyView);
+        adView.setCallToActionView(callToActionView);
+        adView.setIconView(iconView);
 
-        if (nativeAd.getBody() == null) {
-            adView.getBodyView().setVisibility(View.GONE);
-        } else {
-            adView.getBodyView().setVisibility(View.VISIBLE);
-            ((TextView) adView.getBodyView()).setText(nativeAd.getBody());
+        if (headlineView != null) {
+            headlineView.setText(nativeAd.getHeadline());
         }
 
-        if (nativeAd.getCallToAction() == null) {
-            adView.getCallToActionView().setVisibility(View.GONE);
-        } else {
-            adView.getCallToActionView().setVisibility(View.VISIBLE);
-            ((Button) adView.getCallToActionView()).setText(nativeAd.getCallToAction());
+        if (bodyView != null) {
+            if (nativeAd.getBody() == null) {
+                bodyView.setVisibility(View.GONE);
+            } else {
+                bodyView.setVisibility(View.VISIBLE);
+                bodyView.setText(nativeAd.getBody());
+            }
         }
 
-        if (nativeAd.getIcon() == null) {
-            adView.getIconView().setVisibility(View.GONE);
-        } else {
-            ((ImageView) adView.getIconView()).setImageDrawable(nativeAd.getIcon().getDrawable());
-            adView.getIconView().setVisibility(View.VISIBLE);
+        if (callToActionView != null) {
+            if (nativeAd.getCallToAction() == null) {
+                callToActionView.setVisibility(View.GONE);
+            } else {
+                callToActionView.setVisibility(View.VISIBLE);
+                callToActionView.setText(nativeAd.getCallToAction());
+            }
+        }
+
+        if (iconView != null) {
+            if (nativeAd.getIcon() == null) {
+                iconView.setVisibility(View.GONE);
+            } else {
+                iconView.setImageDrawable(nativeAd.getIcon().getDrawable());
+                iconView.setVisibility(View.VISIBLE);
+            }
+        }
+
+        if (mediaView != null) {
+            if (nativeAd.getMediaContent() == null) {
+                mediaView.setVisibility(View.GONE);
+            } else {
+                mediaView.setMediaContent(nativeAd.getMediaContent());
+                mediaView.setVisibility(View.VISIBLE);
+            }
         }
 
         adView.setNativeAd(nativeAd);

--- a/app/src/main/res/layout/native_ad.xml
+++ b/app/src/main/res/layout/native_ad.xml
@@ -19,6 +19,8 @@
                 android:id="@+id/ad_media"
                 android:layout_width="match_parent"
                 android:layout_height="180dp"
+                android:minWidth="120dp"
+                android:minHeight="120dp"
                 android:visibility="gone" />
 
             <LinearLayout


### PR DESCRIPTION
## Summary
- ensure all native ad subviews are bound before use and handle nulls
- show MediaView only when media content exists and set its content
- enforce minimum 120dp dimensions on MediaView in native ad layout

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f04b06e0832dad5938c5f8db5c30