### PR TITLE
feat: refine native ads and promote randomized ad

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ads/managers/NativeAdLoader.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ads/managers/NativeAdLoader.java
@@ -9,6 +9,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.LayoutRes;
 
 import com.d4rk.androidtutorials.java.R;
 import com.google.android.gms.ads.AdLoader;
@@ -23,10 +24,20 @@ import com.google.android.gms.ads.nativead.NativeAdView;
 public class NativeAdLoader {
 
     public static void load(@NonNull Context context, @NonNull ViewGroup container) {
+        load(context, container, R.layout.native_ad);
+    }
+
+    public static void load(@NonNull Context context, @NonNull ViewGroup container, @LayoutRes int layoutRes) {
         AdLoader adLoader = new AdLoader.Builder(context, context.getString(R.string.native_ad_banner_unit_id))
                 .forNativeAd(nativeAd -> {
                     LayoutInflater inflater = LayoutInflater.from(context);
-                    NativeAdView adView = (NativeAdView) inflater.inflate(R.layout.native_ad, container, false);
+                    NativeAdView adView = (NativeAdView) inflater.inflate(layoutRes, container, false);
+                    adView.setLayoutParams(new ViewGroup.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.WRAP_CONTENT));
+                    adView.setPadding(container.getPaddingLeft(), container.getPaddingTop(),
+                            container.getPaddingRight(), container.getPaddingBottom());
+                    container.setPadding(0, 0, 0, 0);
                     populateNativeAdView(nativeAd, adView);
                     container.removeAllViews();
                     container.addView(adView);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeFragment.java
@@ -19,6 +19,7 @@ import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
 import com.bumptech.glide.Glide;
 import dagger.hilt.android.AndroidEntryPoint;
+import com.d4rk.androidtutorials.java.data.model.PromotedApp;
 
 @AndroidEntryPoint
 public class HomeFragment extends Fragment {
@@ -52,19 +53,20 @@ public class HomeFragment extends Fragment {
             binding.scrollView.clearFocus();
             promotedContainer.clearFocus();
             promotedContainer.removeAllViews();
-            java.util.List<com.d4rk.androidtutorials.java.data.model.PromotedApp> apps = state.promotedApps();
+            java.util.List<PromotedApp> apps = state.promotedApps();
             int adPosition = new java.util.Random().nextInt(apps.size() + 1);
             for (int i = 0; i < apps.size(); i++) {
                 if (i == adPosition) {
                     addPromotedAd(promotedContainer);
                 }
+                PromotedApp app = apps.get(i);
                 com.d4rk.androidtutorials.java.databinding.PromotedAppItemBinding itemBinding =
                         com.d4rk.androidtutorials.java.databinding.PromotedAppItemBinding.inflate(inflater, promotedContainer, false);
-                loadImage(apps.get(i).iconUrl(), itemBinding.appIcon);
-                itemBinding.appName.setText(apps.get(i).name());
+                loadImage(app.iconUrl(), itemBinding.appIcon);
+                itemBinding.appName.setText(app.name());
                 itemBinding.appDescription.setVisibility(android.view.View.GONE);
-                itemBinding.appButton.setOnClickListener(v -> startActivity(homeViewModel.getPromotedAppIntent(apps.get(i).packageName())));
-                itemBinding.shareButton.setOnClickListener(v -> shareApp(apps.get(i)));
+                itemBinding.appButton.setOnClickListener(v -> startActivity(homeViewModel.getPromotedAppIntent(app.packageName())));
+                itemBinding.shareButton.setOnClickListener(v -> shareApp(app));
                 promotedContainer.addView(itemBinding.getRoot());
             }
             if (adPosition == apps.size()) {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeFragment.java
@@ -11,6 +11,7 @@ import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.d4rk.androidtutorials.java.databinding.FragmentHomeBinding;
+import com.d4rk.androidtutorials.java.ads.managers.NativeAdLoader;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.MobileAds;
 
@@ -51,15 +52,23 @@ public class HomeFragment extends Fragment {
             binding.scrollView.clearFocus();
             promotedContainer.clearFocus();
             promotedContainer.removeAllViews();
-            for (com.d4rk.androidtutorials.java.data.model.PromotedApp app : state.promotedApps()) {
+            java.util.List<com.d4rk.androidtutorials.java.data.model.PromotedApp> apps = state.promotedApps();
+            int adPosition = new java.util.Random().nextInt(apps.size() + 1);
+            for (int i = 0; i < apps.size(); i++) {
+                if (i == adPosition) {
+                    addPromotedAd(promotedContainer);
+                }
                 com.d4rk.androidtutorials.java.databinding.PromotedAppItemBinding itemBinding =
                         com.d4rk.androidtutorials.java.databinding.PromotedAppItemBinding.inflate(inflater, promotedContainer, false);
-                loadImage(app.iconUrl(), itemBinding.appIcon);
-                itemBinding.appName.setText(app.name());
+                loadImage(apps.get(i).iconUrl(), itemBinding.appIcon);
+                itemBinding.appName.setText(apps.get(i).name());
                 itemBinding.appDescription.setVisibility(android.view.View.GONE);
-                itemBinding.appButton.setOnClickListener(v -> startActivity(homeViewModel.getPromotedAppIntent(app.packageName())));
-                itemBinding.shareButton.setOnClickListener(v -> shareApp(app));
+                itemBinding.appButton.setOnClickListener(v -> startActivity(homeViewModel.getPromotedAppIntent(apps.get(i).packageName())));
+                itemBinding.shareButton.setOnClickListener(v -> shareApp(apps.get(i)));
                 promotedContainer.addView(itemBinding.getRoot());
+            }
+            if (adPosition == apps.size()) {
+                addPromotedAd(promotedContainer);
             }
         });
         new FastScrollerBuilder(binding.scrollView)
@@ -108,5 +117,18 @@ public class HomeFragment extends Fragment {
                 .load(url)
                 .centerInside()
                 .into(imageView);
+    }
+
+    private void addPromotedAd(ViewGroup container) {
+        android.widget.FrameLayout adContainer = new android.widget.FrameLayout(requireContext());
+        ViewGroup.MarginLayoutParams params = new ViewGroup.MarginLayoutParams(dpToPx(160), dpToPx(180));
+        params.setMarginEnd(dpToPx(8));
+        adContainer.setLayoutParams(params);
+        NativeAdLoader.load(requireContext(), adContainer, com.d4rk.androidtutorials.java.R.layout.promoted_native_ad);
+        container.addView(adContainer);
+    }
+
+    private int dpToPx(int dp) {
+        return Math.round(dp * requireContext().getResources().getDisplayMetrics().density);
     }
 }

--- a/app/src/main/res/layout/native_ad.xml
+++ b/app/src/main/res/layout/native_ad.xml
@@ -7,6 +7,8 @@
     <com.google.android.material.card.MaterialCardView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        style="@style/Widget.Material3.CardView.Filled"
         app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.CardView">
 
         <LinearLayout

--- a/app/src/main/res/layout/promoted_native_ad.xml
+++ b/app/src/main/res/layout/promoted_native_ad.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.gms.ads.nativead.NativeAdView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="160dp"
+    android:layout_height="180dp"
+    android:layout_marginEnd="8dp">
+
+    <com.google.android.material.card.MaterialCardView
+        style="@style/Widget.Material3.CardView.Filled"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:cardCornerRadius="24dp">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="8dp">
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/ad_app_icon"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/ad_headline"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:maxLines="2"
+                android:ellipsize="end"
+                android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+                app:layout_constraintTop_toBottomOf="@id/ad_app_icon"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/ad_body"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                app:layout_constraintTop_toBottomOf="@id/ad_headline"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/ad_call_to_action"
+                style="@style/Widget.Material3.Button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                app:layout_constraintTop_toBottomOf="@id/ad_body"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+</com.google.android.gms.ads.nativead.NativeAdView>


### PR DESCRIPTION
## Summary
- improve native ad layout with default margin and Material styling
- allow loading ads with custom layouts and preserve container padding
- show a randomly positioned native ad inside the "More apps" carousel

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f386572c832d9befe507032bfa95