### PR TITLE
feat(ads): support per-screen native ad layouts

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ads/managers/NativeAdLoader.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ads/managers/NativeAdLoader.java
@@ -52,12 +52,14 @@ public class NativeAdLoader {
         TextView bodyView = adView.findViewById(R.id.ad_body);
         Button callToActionView = adView.findViewById(R.id.ad_call_to_action);
         ImageView iconView = adView.findViewById(R.id.ad_app_icon);
+        TextView attributionView = adView.findViewById(R.id.ad_attribution);
 
         adView.setMediaView(mediaView);
         adView.setHeadlineView(headlineView);
         adView.setBodyView(bodyView);
         adView.setCallToActionView(callToActionView);
         adView.setIconView(iconView);
+        adView.setAdvertiserView(attributionView);
 
         if (headlineView != null) {
             headlineView.setText(nativeAd.getHeadline());
@@ -78,6 +80,15 @@ public class NativeAdLoader {
             } else {
                 callToActionView.setVisibility(View.VISIBLE);
                 callToActionView.setText(nativeAd.getCallToAction());
+            }
+        }
+
+        if (attributionView != null) {
+            String adLabel = adView.getContext().getString(R.string.ad);
+            if (nativeAd.getAdvertiser() == null) {
+                attributionView.setText(adLabel);
+            } else {
+                attributionView.setText(adLabel + " " + nativeAd.getAdvertiser());
             }
         }
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ads/views/NativeAdBannerView.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ads/views/NativeAdBannerView.java
@@ -1,12 +1,15 @@
 package com.d4rk.androidtutorials.java.ads.views;
 
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.util.AttributeSet;
 import android.widget.FrameLayout;
 
+import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.d4rk.androidtutorials.java.R;
 import com.google.android.gms.ads.AdRequest;
 import com.d4rk.androidtutorials.java.ads.managers.NativeAdLoader;
 
@@ -16,19 +19,36 @@ import com.d4rk.androidtutorials.java.ads.managers.NativeAdLoader;
  */
 public class NativeAdBannerView extends FrameLayout {
 
+    private int layoutRes = R.layout.native_ad;
+
     public NativeAdBannerView(@NonNull Context context) {
         super(context);
+        init(context, null, 0);
     }
 
     public NativeAdBannerView(@NonNull Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
+        init(context, attrs, 0);
     }
 
     public NativeAdBannerView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
+        init(context, attrs, defStyleAttr);
+    }
+
+    private void init(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        if (attrs != null) {
+            TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.NativeAdBannerView, defStyleAttr, 0);
+            layoutRes = a.getResourceId(R.styleable.NativeAdBannerView_nativeAdLayout, R.layout.native_ad);
+            a.recycle();
+        }
     }
 
     public void loadAd(AdRequest adRequest) {
-        NativeAdLoader.load(getContext(), this);
+        NativeAdLoader.load(getContext(), this, layoutRes);
+    }
+
+    public void setNativeAdLayout(@LayoutRes int layoutRes) {
+        this.layoutRes = layoutRes;
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -57,7 +57,7 @@
             android:id="@+id/ad_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-/>
+            app:nativeAdLayout="@layout/native_ad" />
     </FrameLayout>
 
     <com.google.android.material.bottomnavigation.BottomNavigationView

--- a/app/src/main/res/layout/activity_support.xml
+++ b/app/src/main/res/layout/activity_support.xml
@@ -126,7 +126,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
                 android:layout_marginBottom="16dp"
-/>
+                app:nativeAdLayout="@layout/native_ad" />
         </androidx.appcompat.widget.LinearLayoutCompat>
     </me.zhanghai.android.fastscroll.FastScrollScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -173,7 +173,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            app:layout_constraintTop_toBottomOf="@id/card_view_about" />
+            app:layout_constraintTop_toBottomOf="@id/card_view_about"
+            app:nativeAdLayout="@layout/native_ad" />
 
         <com.airbnb.lottie.LottieAnimationView
             android:id="@+id/animation_about"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -149,7 +149,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
                 android:layout_marginBottom="16dp"
-/>
+                app:nativeAdLayout="@layout/native_ad" />
 
             <androidx.appcompat.widget.LinearLayoutCompat
                 android:id="@+id/other_apps_section"
@@ -219,7 +219,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
-/>
+                app:nativeAdLayout="@layout/native_ad" />
 
             <com.airbnb.lottie.LottieAnimationView
                 android:id="@+id/learningAnimation"

--- a/app/src/main/res/layout/native_ad.xml
+++ b/app/src/main/res/layout/native_ad.xml
@@ -17,6 +17,13 @@
             android:orientation="vertical"
             android:padding="8dp">
 
+            <TextView
+                android:id="@+id/ad_attribution"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/ad"
+                android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
+
             <com.google.android.gms.ads.nativead.MediaView
                 android:id="@+id/ad_media"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/promoted_native_ad.xml
+++ b/app/src/main/res/layout/promoted_native_ad.xml
@@ -16,11 +16,20 @@
             android:layout_height="match_parent"
             android:padding="8dp">
 
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/ad_attribution"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/ad"
+                android:textAppearance="@style/TextAppearance.Material3.LabelSmall"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
             <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/ad_app_icon"
                 android:layout_width="48dp"
                 android:layout_height="48dp"
-                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/ad_attribution"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -21,6 +21,7 @@
     <string name="get_on_google_play">نزّله من على Google Play</string>
     <string name="learn_more">اعرف المزيد</string>
     <string name="play_store">متجر Play</string>
+    <string name="ad">إعلان</string>
     <string name="search_tutorials_hint">ابحث عن الدروس</string>
     <string name="search_tutorials_content_description">ابحث عن الدروس</string>
     <string name="search_lessons_hint">ابحث عن الدروس</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -24,6 +24,7 @@
     <string name="get_on_google_play">Вземете от Google Play</string>
     <string name="learn_more">Научете повече</string>
     <string name="play_store">Play Store</string>
+    <string name="ad">Реклама</string>
     <string name="search_tutorials_hint">Търсене на уроци</string>
     <string name="search_tutorials_content_description">Търсене на уроци</string>
     <string name="search_lessons_hint">Търсене на уроци</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -24,6 +24,7 @@
     <string name="get_on_google_play">গুগল প্লে থেকে পান</string>
     <string name="learn_more">আরও জানুন</string>
     <string name="play_store">প্লে স্টোর</string>
+    <string name="ad">বিজ্ঞাপন</string>
     <string name="search_tutorials_hint">টিউটোরিয়াল খুঁজুন</string>
     <string name="search_tutorials_content_description">টিউটোরিয়াল খুঁজুন</string>
     <string name="search_lessons_hint">পাঠ খুঁজুন</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -24,6 +24,7 @@
     <string name="get_on_google_play">Jetzt bei Google Play</string>
     <string name="learn_more">Mehr erfahren</string>
     <string name="play_store">Play Store</string>
+    <string name="ad">Anzeige</string>
     <string name="search_tutorials_hint">Tutorials suchen</string>
     <string name="search_tutorials_content_description">Tutorials suchen</string>
     <string name="search_lessons_hint">Lektionen suchen</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -24,6 +24,7 @@
     <string name="get_on_google_play">Consíguelo en Google Play</string>
     <string name="learn_more">Más información</string>
     <string name="play_store">Play Store</string>
+    <string name="ad">Anuncio</string>
     <string name="search_tutorials_hint">Buscar tutoriales</string>
     <string name="search_tutorials_content_description">Buscar tutoriales</string>
     <string name="search_lessons_hint">Buscar lecciones</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -21,6 +21,7 @@
     <string name="get_on_google_play">Descárgala en Google Play</string>
     <string name="learn_more">Más información</string>
     <string name="play_store">Play Store</string>
+    <string name="ad">Anuncio</string>
     <string name="search_tutorials_hint">Buscar tutoriales</string>
     <string name="search_tutorials_content_description">Buscar tutoriales</string>
     <string name="search_lessons_hint">Buscar lecciones</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -21,6 +21,7 @@
     <string name="get_on_google_play">Kunin ito sa Google Play</string>
     <string name="learn_more">Matuto pa</string>
     <string name="play_store">Play Store</string>
+    <string name="ad">Ad</string>
     <string name="search_tutorials_hint">Maghanap ng mga tutorial</string>
     <string name="search_tutorials_content_description">Maghanap ng mga tutorial</string>
     <string name="search_lessons_hint">Maghanap ng mga aralin</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -24,6 +24,7 @@
     <string name="get_on_google_play">Obtenez-le sur Google Play</string>
     <string name="learn_more">En savoir plus</string>
     <string name="play_store">Play Store</string>
+    <string name="ad">Annonce</string>
     <string name="search_tutorials_hint">Rechercher des tutoriels</string>
     <string name="search_tutorials_content_description">Rechercher des tutoriels</string>
     <string name="search_lessons_hint">Rechercher des leçons</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -25,6 +25,7 @@
     <string name="get_on_google_play">इसे Google Play पर प्राप्त करें</string>
     <string name="learn_more">और जानें</string>
     <string name="play_store">प्ले स्टोर</string>
+    <string name="ad">विज्ञापन</string>
     <string name="search_tutorials_hint">ट्यूटोरियल खोजें</string>
     <string name="search_tutorials_content_description">ट्यूटोरियल खोजें</string>
     <string name="search_lessons_hint">पाठ खोजें</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -26,6 +26,7 @@
     <string name="get_on_google_play">Szerezd meg a Google Playen</string>
     <string name="learn_more">Tudj meg többet</string>
     <string name="play_store">Play Áruház</string>
+    <string name="ad">Hirdetés</string>
     <string name="search_tutorials_hint">Oktatóanyagok keresése</string>
     <string name="search_tutorials_content_description">Oktatóanyagok keresése</string>
     <string name="search_lessons_hint">Leckék keresése</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -24,6 +24,7 @@
     <string name="get_on_google_play">Dapatkan di Google Play</string>
     <string name="learn_more">Pelajari lebih lanjut</string>
     <string name="play_store">Play Store</string>
+    <string name="ad">Iklan</string>
     <string name="search_tutorials_hint">Cari tutorial</string>
     <string name="search_tutorials_content_description">Cari tutorial</string>
     <string name="search_lessons_hint">Cari pelajaran</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -26,6 +26,7 @@
     <string name="get_on_google_play">Scaricalo su Google Play</string>
     <string name="learn_more">Scopri di più</string>
     <string name="play_store">Play Store</string>
+    <string name="ad">Annuncio</string>
     <string name="search_tutorials_hint">Cerca tutorial</string>
     <string name="search_tutorials_content_description">Cerca tutorial</string>
     <string name="search_lessons_hint">Cerca lezioni</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -26,6 +26,7 @@
     <string name="get_on_google_play">Google Play で入手しよう</string>
     <string name="learn_more">詳しく見る</string>
     <string name="play_store">Play ストア</string>
+    <string name="ad">広告</string>
     <string name="search_tutorials_hint">チュートリアルを検索</string>
     <string name="search_tutorials_content_description">チュートリアルを検索</string>
     <string name="search_lessons_hint">レッスンを検索</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -21,6 +21,7 @@
     <string name="get_on_google_play">Google Play에서 다운로드</string>
     <string name="learn_more">자세히 알아보기</string>
     <string name="play_store">Play 스토어</string>
+    <string name="ad">광고</string>
     <string name="search_tutorials_hint">튜토리얼 검색</string>
     <string name="search_tutorials_content_description">튜토리얼 검색</string>
     <string name="search_lessons_hint">강의 검색</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -26,6 +26,7 @@
     <string name="get_on_google_play">Pobierz z Google Play</string>
     <string name="learn_more">Dowiedz się więcej</string>
     <string name="play_store">Sklep Play</string>
+    <string name="ad">Reklama</string>
     <string name="search_tutorials_hint">Wyszukaj samouczki</string>
     <string name="search_tutorials_content_description">Wyszukaj samouczki</string>
     <string name="search_lessons_hint">Wyszukaj lekcje</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -21,6 +21,7 @@
     <string name="get_on_google_play">Disponível no Google Play</string>
     <string name="learn_more">Saiba mais</string>
     <string name="play_store">Play Store</string>
+    <string name="ad">Anúncio</string>
     <string name="search_tutorials_hint">Pesquisar tutoriais</string>
     <string name="search_tutorials_content_description">Pesquisar tutoriais</string>
     <string name="search_lessons_hint">Pesquisar lições</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -24,6 +24,7 @@
     <string name="get_on_google_play">Ia-l de pe Google Play</string>
     <string name="learn_more">Află mai multe</string>
     <string name="play_store">Magazin Play</string>
+    <string name="ad">Anunț</string>
     <string name="search_tutorials_hint">Caută tutoriale</string>
     <string name="search_tutorials_content_description">Caută tutoriale</string>
     <string name="search_lessons_hint">Caută lecții</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -24,6 +24,7 @@
     <string name="get_on_google_play">Получить в Google Play</string>
     <string name="learn_more">Узнать больше</string>
     <string name="play_store">Play Маркет</string>
+    <string name="ad">Реклама</string>
     <string name="search_tutorials_hint">Поиск руководств</string>
     <string name="search_tutorials_content_description">Поиск руководств</string>
     <string name="search_lessons_hint">Поиск уроков</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -21,6 +21,7 @@
     <string name="get_on_google_play">Hämta den på Google Play</string>
     <string name="learn_more">Läs mer</string>
     <string name="play_store">Play Butik</string>
+    <string name="ad">Annons</string>
     <string name="search_tutorials_hint">Sök handledningar</string>
     <string name="search_tutorials_content_description">Sök handledningar</string>
     <string name="search_lessons_hint">Sök lektioner</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -21,6 +21,7 @@
     <string name="get_on_google_play">ดาวน์โหลดได้ที่ Google Play</string>
     <string name="learn_more">เรียนรู้เพิ่มเติม</string>
     <string name="play_store">Play Store</string>
+    <string name="ad">โฆษณา</string>
     <string name="search_tutorials_hint">ค้นหาบทช่วยสอน</string>
     <string name="search_tutorials_content_description">ค้นหาบทช่วยสอน</string>
     <string name="search_lessons_hint">ค้นหาบทเรียน</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -21,6 +21,7 @@
     <string name="get_on_google_play">Google Play\'den edinin</string>
     <string name="learn_more">Daha fazla bilgi edinin</string>
     <string name="play_store">Play Store</string>
+    <string name="ad">Reklam</string>
     <string name="search_tutorials_hint">Eğitimleri ara</string>
     <string name="search_tutorials_content_description">Eğitimleri ara</string>
     <string name="search_lessons_hint">Dersleri ara</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -21,6 +21,7 @@
     <string name="get_on_google_play">Завантажте з Google Play</string>
     <string name="learn_more">Дізнайтеся більше</string>
     <string name="play_store">Play Store</string>
+    <string name="ad">Реклама</string>
     <string name="search_tutorials_hint">Пошук навчальних посібників</string>
     <string name="search_tutorials_content_description">Пошук навчальних посібників</string>
     <string name="search_lessons_hint">Пошук уроків</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -21,6 +21,7 @@
     <string name="get_on_google_play">اسے گوگل پلے سے حاصل کریں</string>
     <string name="learn_more">مزید جانیں</string>
     <string name="play_store">پلے اسٹور</string>
+    <string name="ad">اشتہار</string>
     <string name="search_tutorials_hint">ٹیوٹوریلز تلاش کریں</string>
     <string name="search_tutorials_content_description">ٹیوٹوریلز تلاش کریں</string>
     <string name="search_lessons_hint">سبق تلاش کریں</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -21,6 +21,7 @@
     <string name="get_on_google_play">Tải trên Google Play</string>
     <string name="learn_more">Tìm hiểu thêm</string>
     <string name="play_store">Cửa hàng Play</string>
+    <string name="ad">Quảng cáo</string>
     <string name="search_tutorials_hint">Tìm kiếm hướng dẫn</string>
     <string name="search_tutorials_content_description">Tìm kiếm hướng dẫn</string>
     <string name="search_lessons_hint">Tìm kiếm bài học</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -21,6 +21,7 @@
     <string name="get_on_google_play">在 Google Play 上取得</string>
     <string name="learn_more">瞭解更多</string>
     <string name="play_store">Play 商店</string>
+    <string name="ad">廣告</string>
     <string name="search_tutorials_hint">搜尋教學</string>
     <string name="search_tutorials_content_description">搜尋教學</string>
     <string name="search_lessons_hint">搜尋課程</string>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="NativeAdBannerView">
+        <attr name="nativeAdLayout" format="reference" />
+    </declare-styleable>
+</resources>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,8 +23,9 @@
     <string name="main_card_description">The Kotlin Edition has been updated with dynamic lessons, AI assistant, and more. Experience the future of Android development.</string>
       <string name="get_on_google_play">Get it on Google Play</string>
       <string name="learn_more">Learn more</string>
-      <string name="play_store">Play Store</string>
-      <string name="search_tutorials_hint">Search tutorials</string>
+    <string name="play_store">Play Store</string>
+    <string name="ad">Ad</string>
+    <string name="search_tutorials_hint">Search tutorials</string>
       <string name="search_tutorials_content_description">Search tutorials</string>
       <string name="search_lessons_hint">Search lessons</string>
       <string name="search_lessons_content_description">Search lessons</string>


### PR DESCRIPTION
## Summary
- allow setting custom native ad layouts via `nativeAdLayout` attribute
- add advertiser attribution label for policy compliance
- wire up example screens with layout-specific native ads

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c03986a030832db0f00e2bb655c500