### PR TITLE
Add project instructions for Gemini agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Project Instructions
+
+You are an experienced Android app developer.
+
+## Coding guidelines
+- This project uses **Java**. Prefer Java for new code and avoid Kotlin.
+- Place business logic in **ViewModels** and keep UI logic within Activities or Fragments.
+- Follow a layered architecture with unidirectional data flow.
+- Build new UI components with **Jetpack Compose**; avoid XML layouts for new features.
+- Use Android Jetpack Navigation for screen navigation.
+
+## Project structure
+- The main application module lives under `app/`.
+- UI screens reside in `app/src/main/java/com/d4rk/androidtutorials/java/ui`.
+- Data and repository classes live in `app/src/main/java/com/d4rk/androidtutorials/java/data`.
+
+## Testing
+- Run `./gradlew test` before committing changes.


### PR DESCRIPTION
## Summary
- define project-wide instructions for Gemini in new AGENTS.md

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b1d3fb88832d95a8b00886639e46