### PR TITLE
Fix Data Binding ID Collisions in Onboarding Layouts

### DIFF
--- a/app/src/main/res/layout/fragment_onboarding_selection.xml
+++ b/app/src/main/res/layout/fragment_onboarding_selection.xml
@@ -55,7 +55,7 @@
         android:padding="24dp">
 
         <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/title"
+            android:id="@+id/title_text"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="32dp"
@@ -67,7 +67,7 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/description"
+            android:id="@+id/description_text"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
@@ -77,7 +77,7 @@
             android:textColor="?attr/colorOnSurfaceVariant"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/title" />
+            app:layout_constraintTop_toBottomOf="@id/title_text" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/selection_group"
@@ -87,7 +87,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/description">
+            app:layout_constraintTop_toBottomOf="@id/description_text">
 
             <RadioGroup
                 android:id="@+id/option_group"

--- a/app/src/main/res/layout/item_onboarding_option.xml
+++ b/app/src/main/res/layout/item_onboarding_option.xml
@@ -14,7 +14,7 @@
         android:padding="12dp">
 
         <androidx.appcompat.widget.AppCompatImageView
-            android:id="@+id/icon"
+            android:id="@+id/icon_view"
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:src="@{icon}"
@@ -34,7 +34,7 @@
             android:textAppearance="?attr/textAppearanceTitleMedium"
             android:breakStrategy="balanced"
             android:hyphenationFrequency="none"
-            app:layout_constraintStart_toEndOf="@id/icon"
+            app:layout_constraintStart_toEndOf="@id/icon_view"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintEnd_toStartOf="@id/radio_button"
             tools:text="Light mode"/>


### PR DESCRIPTION
## Summary
- Rename `title` and `description` view IDs in onboarding selection layout to avoid data binding collisions
- Rename `icon` view ID in onboarding option layout to resolve binding conflict

## Testing
- `./gradlew test` *(fails: SDK license not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68c551c9742c832d8dfc49f4853eb9f4