### PR TITLE
Centralize Mobile Ads initialization with AdUtils

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ads/AdUtils.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ads/AdUtils.java
@@ -1,0 +1,31 @@
+package com.d4rk.androidtutorials.java.ads;
+
+import android.content.Context;
+import android.view.View;
+
+import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.AdView;
+import com.google.android.gms.ads.MobileAds;
+
+public final class AdUtils {
+    private static boolean initialized = false;
+
+    private AdUtils() {
+        // no-op
+    }
+
+    public static synchronized void initialize(Context context) {
+        if (!initialized) {
+            MobileAds.initialize(context.getApplicationContext());
+            initialized = true;
+        }
+    }
+
+    public static void loadBanner(View adView) {
+        if (adView instanceof AdView) {
+            AdView view = (AdView) adView;
+            initialize(view.getContext());
+            view.loadAd(new AdRequest.Builder().build());
+        }
+    }
+}

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ads/managers/AppOpenAd.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ads/managers/AppOpenAd.java
@@ -18,7 +18,7 @@ import com.google.android.gms.ads.AdError;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.FullScreenContentCallback;
 import com.google.android.gms.ads.LoadAdError;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 import com.google.android.gms.ads.appopen.AppOpenAd.AppOpenAdLoadCallback;
 
 import java.util.Date;
@@ -35,10 +35,7 @@ public class AppOpenAd extends Application implements ActivityLifecycleCallbacks
     public void onCreate() {
         super.onCreate();
         registerActivityLifecycleCallbacks(this);
-        MobileAds.initialize(
-                this,
-                initializationStatus -> {
-                });
+        AdUtils.initialize(this);
         CookieManager.getInstance();
         ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
         appOpenAdManager = new AppOpenAdManager(this);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/DefaultSupportRepository.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/repository/DefaultSupportRepository.java
@@ -12,7 +12,7 @@ import com.android.billingclient.api.PendingPurchasesParams;
 import com.android.billingclient.api.ProductDetails;
 import com.android.billingclient.api.QueryProductDetailsParams;
 import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -150,7 +150,7 @@ public class DefaultSupportRepository implements SupportRepository {
      * can be done here if needed for the support screen).
      */
     public AdRequest initMobileAds() {
-        MobileAds.initialize(context);
+        AdUtils.initialize(context);
         return new AdRequest.Builder().build();
     }
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/about/AboutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/about/AboutFragment.java
@@ -18,8 +18,7 @@ import com.d4rk.androidtutorials.java.BuildConfig;
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.FragmentAboutBinding;
 import com.d4rk.androidtutorials.java.utils.ConsentUtils;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import dagger.hilt.android.AndroidEntryPoint;
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
@@ -42,9 +41,8 @@ public class AboutFragment extends Fragment {
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
 
         if (ConsentUtils.canShowAds(requireContext())) {
-            MobileAds.initialize(requireContext());
             binding.adView.setVisibility(android.view.View.VISIBLE);
-            binding.adView.loadAd(new AdRequest.Builder().build());
+            AdUtils.loadBanner(binding.adView);
         } else {
             binding.adView.setVisibility(android.view.View.GONE);
         }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/AndroidStudioFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/AndroidStudioFragment.java
@@ -34,7 +34,7 @@ import com.d4rk.androidtutorials.java.databinding.ItemAndroidStudioCategoryBindi
 import com.d4rk.androidtutorials.java.databinding.ItemAndroidStudioLessonBinding;
 import com.google.android.gms.ads.AdListener;
 import com.google.android.gms.ads.LoadAdError;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 import com.google.android.material.card.MaterialCardView;
 import com.google.android.material.textview.MaterialTextView;
 import com.google.android.material.shape.CornerFamily;
@@ -138,7 +138,7 @@ public class AndroidStudioFragment extends Fragment {
 
     private void ensureMobileAdsInitialized() {
         if (!mobileAdsInitialized) {
-            MobileAds.initialize(requireContext());
+            AdUtils.initialize(requireContext());
             mobileAdsInitialized = true;
         }
     }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/history/AndroidHistory.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/history/AndroidHistory.java
@@ -5,8 +5,7 @@ import android.os.Bundle;
 import com.d4rk.androidtutorials.java.databinding.ActivityAndroidHistoryBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
@@ -16,12 +15,10 @@ public class AndroidHistory extends UpNavigationActivity {
         super.onCreate(savedInstanceState);
         ActivityAndroidHistoryBinding binding = ActivityAndroidHistoryBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
-        MobileAds.initialize(this);
-
         EdgeToEdgeDelegate.apply(this, binding.scrollView);
 
-        binding.adView.loadAd(new AdRequest.Builder().build());
-        binding.adViewBottom.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
+        AdUtils.loadBanner(binding.adViewBottom);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/permissions/PermissionsTutorialActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/permissions/PermissionsTutorialActivity.java
@@ -7,8 +7,7 @@ import android.os.Bundle;
 import com.d4rk.androidtutorials.java.databinding.ActivityPermissionsTutorialBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
@@ -18,12 +17,10 @@ public class PermissionsTutorialActivity extends UpNavigationActivity {
         super.onCreate(savedInstanceState);
         com.d4rk.androidtutorials.java.databinding.ActivityPermissionsTutorialBinding binding = ActivityPermissionsTutorialBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
-        MobileAds.initialize(this);
-
         EdgeToEdgeDelegate.apply(this, binding.scrollView);
 
-        binding.adViewBottom.loadAd(new AdRequest.Builder().build());
-        binding.adViewLarge.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adViewBottom);
+        AdUtils.loadBanner(binding.adViewLarge);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
         binding.buttonMore.setOnClickListener(v -> startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://developer.android.com/guide/topics/permissions/overview"))));
     }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/sdk/AndroidSDK.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/sdk/AndroidSDK.java
@@ -12,8 +12,7 @@ import com.d4rk.androidtutorials.java.data.model.AndroidVersion;
 import com.d4rk.androidtutorials.java.databinding.ActivityAndroidSdkBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.util.Arrays;
 import java.util.List;
@@ -65,13 +64,10 @@ public class AndroidSDK extends UpNavigationActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         binding = ActivityAndroidSdkBinding.inflate(getLayoutInflater());
-        setContentView(binding.getRoot());
+        setContentView(binding.getRoot());        EdgeToEdgeDelegate.apply(this, binding.scrollView);
 
-        MobileAds.initialize(this);
-        EdgeToEdgeDelegate.apply(this, binding.scrollView);
-
-        binding.adViewBottom.loadAd(new AdRequest.Builder().build());
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adViewBottom);
+        AdUtils.loadBanner(binding.adView);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
 
         createDynamicTable();

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/ShortcutsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/ShortcutsActivity.java
@@ -11,8 +11,7 @@ import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivityShortcutsBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 public class ShortcutsActivity extends UpNavigationActivity {
     @Override
@@ -21,10 +20,7 @@ public class ShortcutsActivity extends UpNavigationActivity {
         ActivityShortcutsBinding binding = ActivityShortcutsBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
-        EdgeToEdgeDelegate.apply(this, binding.container);
-
-        MobileAds.initialize(this);
-        binding.adViewBottom.loadAd(new AdRequest.Builder().build());
+        EdgeToEdgeDelegate.apply(this, binding.container);        AdUtils.loadBanner(binding.adViewBottom);
 
         getSupportFragmentManager().beginTransaction().replace(R.id.frame_layout_shortcuts, new SettingsFragment()).commit();
         ActionBar supportActionBar = getSupportActionBar();

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/BuildShortcutsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/BuildShortcutsActivity.java
@@ -5,8 +5,7 @@ import android.os.Bundle;
 import com.d4rk.androidtutorials.java.databinding.ActivityShortcutsBuildBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
@@ -16,11 +15,9 @@ public class BuildShortcutsActivity extends UpNavigationActivity {
         super.onCreate(savedInstanceState);
         com.d4rk.androidtutorials.java.databinding.ActivityShortcutsBuildBinding binding = ActivityShortcutsBuildBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
-        MobileAds.initialize(this);
-
         EdgeToEdgeDelegate.apply(this, binding.scrollView);
 
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/CodeShortcutsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/CodeShortcutsActivity.java
@@ -5,8 +5,7 @@ import android.os.Bundle;
 import com.d4rk.androidtutorials.java.databinding.ActivityShortcutsCodeBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
@@ -16,11 +15,9 @@ public class CodeShortcutsActivity extends UpNavigationActivity {
         super.onCreate(savedInstanceState);
         ActivityShortcutsCodeBinding binding = ActivityShortcutsCodeBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
-        MobileAds.initialize(this);
-
         EdgeToEdgeDelegate.apply(this, binding.scrollView);
 
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/DebuggingShortcutsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/DebuggingShortcutsActivity.java
@@ -5,8 +5,7 @@ import android.os.Bundle;
 import com.d4rk.androidtutorials.java.databinding.ActivityShortcutsDebuggingBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
@@ -18,10 +17,7 @@ public class DebuggingShortcutsActivity extends UpNavigationActivity {
         setContentView(binding.getRoot());
 
 
-        EdgeToEdgeDelegate.apply(this, binding.scrollView);
-
-        MobileAds.initialize(this);
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        EdgeToEdgeDelegate.apply(this, binding.scrollView);        AdUtils.loadBanner(binding.adView);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/GeneralShortcutsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/GeneralShortcutsActivity.java
@@ -5,8 +5,7 @@ import android.os.Bundle;
 import com.d4rk.androidtutorials.java.databinding.ActivityShortcutsGeneralBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
@@ -16,11 +15,9 @@ public class GeneralShortcutsActivity extends UpNavigationActivity {
         super.onCreate(savedInstanceState);
         com.d4rk.androidtutorials.java.databinding.ActivityShortcutsGeneralBinding binding = ActivityShortcutsGeneralBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
-        MobileAds.initialize(this);
-
         EdgeToEdgeDelegate.apply(this, binding.scrollView);
 
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/NavigationAndSearchingShortcutsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/NavigationAndSearchingShortcutsActivity.java
@@ -14,8 +14,7 @@ import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivityShortcutsNavigationAndSearchingBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.util.List;
 
@@ -27,11 +26,9 @@ public class NavigationAndSearchingShortcutsActivity extends UpNavigationActivit
         super.onCreate(savedInstanceState);
         ActivityShortcutsNavigationAndSearchingBinding binding = ActivityShortcutsNavigationAndSearchingBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
-        MobileAds.initialize(this);
-
         EdgeToEdgeDelegate.apply(this, binding.shortcutList);
 
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
         new FastScrollerBuilder(binding.shortcutList).useMd2Style().build();
 
         List<Shortcut> shortcuts = List.of(

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/RefactoringShortcutsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/RefactoringShortcutsActivity.java
@@ -5,8 +5,7 @@ import android.os.Bundle;
 import com.d4rk.androidtutorials.java.databinding.ActivityShortcutsRefractoringBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
@@ -16,11 +15,9 @@ public class RefactoringShortcutsActivity extends UpNavigationActivity {
         super.onCreate(savedInstanceState);
         com.d4rk.androidtutorials.java.databinding.ActivityShortcutsRefractoringBinding binding = ActivityShortcutsRefractoringBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
-        MobileAds.initialize(this);
-
         EdgeToEdgeDelegate.apply(this, binding.scrollView);
 
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/VersionControlShortcutsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/VersionControlShortcutsActivity.java
@@ -5,8 +5,7 @@ import android.os.Bundle;
 import com.d4rk.androidtutorials.java.databinding.ActivityShortcutsVersionControlBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
@@ -16,11 +15,9 @@ public class VersionControlShortcutsActivity extends UpNavigationActivity {
         super.onCreate(savedInstanceState);
         com.d4rk.androidtutorials.java.databinding.ActivityShortcutsVersionControlBinding binding = ActivityShortcutsVersionControlBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
-        MobileAds.initialize(this);
-
         EdgeToEdgeDelegate.apply(this, binding.scrollView);
 
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/viewbinding/ViewBindingTutorialActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/viewbinding/ViewBindingTutorialActivity.java
@@ -16,7 +16,7 @@ import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.google.android.gms.ads.AdRequest;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -38,8 +38,8 @@ public class ViewBindingTutorialActivity extends UpNavigationActivity {
 
         EdgeToEdgeDelegate.apply(this, binding.scrollView);
 
-        binding.adViewBottom.loadAd(new AdRequest.Builder().build());
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adViewBottom);
+        AdUtils.loadBanner(binding.adView);
         binding.moreAboutViewBindingButton.setOnClickListener(v ->
                 startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://developer.android.com/topic/libraries/view-binding#java"))));
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/tabs/ButtonsTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/tabs/ButtonsTabCodeFragment.java
@@ -17,7 +17,7 @@ import com.d4rk.androidtutorials.java.databinding.FragmentSameCodeBinding;
 import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.google.android.gms.ads.AdRequest;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -32,7 +32,7 @@ public class ButtonsTabCodeFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         FragmentSameCodeBinding binding = FragmentSameCodeBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/tabs/ButtonsTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/tabs/ButtonsTabLayoutFragment.java
@@ -18,7 +18,7 @@ import com.d4rk.androidtutorials.java.databinding.FragmentButtonsLayoutBinding;
 import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.google.android.gms.ads.AdRequest;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -37,7 +37,7 @@ public class ButtonsTabLayoutFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         FragmentButtonsLayoutBinding binding = FragmentButtonsLayoutBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/clock/tabs/ClockTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/clock/tabs/ClockTabCodeFragment.java
@@ -9,15 +9,13 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
 import com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 public class ClockTabCodeFragment extends Fragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding binding = FragmentNoCodeBinding.inflate(inflater, container, false);
-        MobileAds.initialize(requireContext());
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
         return binding.getRoot();
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/clock/tabs/ClockTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/clock/tabs/ClockTabLayoutFragment.java
@@ -18,7 +18,7 @@ import com.d4rk.androidtutorials.java.databinding.FragmentClockLayoutBinding;
 import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.google.android.gms.ads.AdRequest;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -32,7 +32,7 @@ public class ClockTabLayoutFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         FragmentClockLayoutBinding binding = FragmentClockLayoutBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/data/room/tabs/RoomTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/data/room/tabs/RoomTabCodeFragment.java
@@ -17,7 +17,7 @@ import com.d4rk.androidtutorials.java.databinding.FragmentCodeBinding;
 import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.google.android.gms.ads.AdRequest;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -35,7 +35,7 @@ public class RoomTabCodeFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         FragmentCodeBinding binding = FragmentCodeBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/data/room/tabs/RoomTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/data/room/tabs/RoomTabLayoutFragment.java
@@ -17,7 +17,7 @@ import com.d4rk.androidtutorials.java.databinding.FragmentLayoutBinding;
 import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.google.android.gms.ads.AdRequest;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -35,7 +35,7 @@ public class RoomTabLayoutFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         FragmentLayoutBinding binding = FragmentLayoutBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/linear/tabs/LinearLayoutTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/linear/tabs/LinearLayoutTabCodeFragment.java
@@ -9,15 +9,13 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
 import com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 public class LinearLayoutTabCodeFragment extends Fragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding binding = FragmentNoCodeBinding.inflate(inflater, container, false);
-        MobileAds.initialize(requireContext());
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
         return binding.getRoot();
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/linear/tabs/LinearLayoutTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/linear/tabs/LinearLayoutTabLayoutFragment.java
@@ -17,7 +17,7 @@ import com.d4rk.androidtutorials.java.databinding.FragmentLinearLayoutLayoutBind
 import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.google.android.gms.ads.AdRequest;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -31,7 +31,7 @@ public class LinearLayoutTabLayoutFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         FragmentLinearLayoutLayoutBinding binding = FragmentLinearLayoutLayoutBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/relative/tabs/RelativeLayoutTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/relative/tabs/RelativeLayoutTabCodeFragment.java
@@ -9,15 +9,13 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
 import com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 public class RelativeLayoutTabCodeFragment extends Fragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding binding = FragmentNoCodeBinding.inflate(inflater, container, false);
-        MobileAds.initialize(requireContext());
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
         return binding.getRoot();
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/relative/tabs/RelativeLayoutTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/relative/tabs/RelativeLayoutTabLayoutFragment.java
@@ -17,7 +17,7 @@ import com.d4rk.androidtutorials.java.databinding.FragmentLayoutBinding;
 import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.google.android.gms.ads.AdRequest;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -32,7 +32,7 @@ public class RelativeLayoutTabLayoutFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         FragmentLayoutBinding binding = FragmentLayoutBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/table/tabs/TableLayoutTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/table/tabs/TableLayoutTabCodeFragment.java
@@ -9,15 +9,13 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
 import com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 public class TableLayoutTabCodeFragment extends Fragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding binding = FragmentNoCodeBinding.inflate(inflater, container, false);
-        MobileAds.initialize(requireContext());
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
         return binding.getRoot();
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/table/tabs/TableLayoutTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/table/tabs/TableLayoutTabLayoutFragment.java
@@ -17,7 +17,7 @@ import com.d4rk.androidtutorials.java.databinding.FragmentLayoutBinding;
 import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.google.android.gms.ads.AdRequest;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -32,7 +32,7 @@ public class TableLayoutTabLayoutFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         FragmentLayoutBinding binding = FragmentLayoutBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/networking/retrofit/tabs/RetrofitTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/networking/retrofit/tabs/RetrofitTabCodeFragment.java
@@ -17,7 +17,7 @@ import com.d4rk.androidtutorials.java.databinding.FragmentCodeBinding;
 import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.google.android.gms.ads.AdRequest;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -35,7 +35,7 @@ public class RetrofitTabCodeFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         FragmentCodeBinding binding = FragmentCodeBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/networking/retrofit/tabs/RetrofitTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/networking/retrofit/tabs/RetrofitTabLayoutFragment.java
@@ -17,7 +17,7 @@ import com.d4rk.androidtutorials.java.databinding.FragmentLayoutBinding;
 import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.google.android.gms.ads.AdRequest;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -35,7 +35,7 @@ public class RetrofitTabLayoutFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         FragmentLayoutBinding binding = FragmentLayoutBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/progress/progressbar/tabs/ProgressBarTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/progress/progressbar/tabs/ProgressBarTabCodeFragment.java
@@ -17,7 +17,7 @@ import com.d4rk.androidtutorials.java.databinding.FragmentCodeBinding;
 import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.google.android.gms.ads.AdRequest;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -32,7 +32,7 @@ public class ProgressBarTabCodeFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         FragmentCodeBinding binding = FragmentCodeBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/progress/progressbar/tabs/ProgressBarTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/progress/progressbar/tabs/ProgressBarTabLayoutFragment.java
@@ -17,7 +17,7 @@ import com.d4rk.androidtutorials.java.databinding.FragmentLinearLayoutLayoutBind
 import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.google.android.gms.ads.AdRequest;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -31,7 +31,7 @@ public class ProgressBarTabLayoutFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         FragmentLinearLayoutLayoutBinding binding = FragmentLinearLayoutLayoutBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/start/AndroidStartProjectActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/start/AndroidStartProjectActivity.java
@@ -9,8 +9,7 @@ import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivityAndroidStartProjectBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
@@ -36,11 +35,8 @@ public class AndroidStartProjectActivity extends UpNavigationActivity {
                 return true;
             }
             return false;
-        });
-
-        MobileAds.initialize(this);
-        binding.adViewBottom.loadAd(new AdRequest.Builder().build());
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        });        AdUtils.loadBanner(binding.adViewBottom);
+        AdUtils.loadBanner(binding.adView);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
         binding.textViewThirdStepSummary.setMovementMethod(LinkMovementMethod.getInstance());
     }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/images/tabs/ImagesTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/images/tabs/ImagesTabCodeFragment.java
@@ -9,15 +9,13 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
 import com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 public class ImagesTabCodeFragment extends Fragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding binding = FragmentNoCodeBinding.inflate(inflater, container, false);
-        MobileAds.initialize(requireContext());
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
         return binding.getRoot();
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/images/tabs/ImagesTabLayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/images/tabs/ImagesTabLayoutFragment.java
@@ -17,7 +17,7 @@ import com.d4rk.androidtutorials.java.databinding.FragmentLayoutBinding;
 import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.google.android.gms.ads.AdRequest;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -32,7 +32,7 @@ public class ImagesTabLayoutFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         FragmentLayoutBinding binding = FragmentLayoutBinding.inflate(inflater, container, false);
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/tabs/CodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/tabs/CodeFragment.java
@@ -18,7 +18,7 @@ import com.d4rk.androidtutorials.java.databinding.FragmentCodeBinding;
 import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.google.android.gms.ads.AdRequest;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -57,7 +57,7 @@ public class CodeFragment extends Fragment {
 
     private void setupUI() {
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/tabs/LayoutFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/tabs/LayoutFragment.java
@@ -18,7 +18,7 @@ import com.d4rk.androidtutorials.java.databinding.FragmentLayoutBinding;
 import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.google.android.gms.ads.AdRequest;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -57,7 +57,7 @@ public class LayoutFragment extends Fragment {
 
     private void setupUI() {
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/tabs/NoCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/tabs/NoCodeFragment.java
@@ -11,8 +11,7 @@ import androidx.fragment.app.Fragment;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 public class NoCodeFragment extends Fragment {
     private static final String ARG_MESSAGE = "arg_message";
@@ -31,8 +30,7 @@ public class NoCodeFragment extends Fragment {
                              ViewGroup container,
                              Bundle savedInstanceState) {
         FragmentNoCodeBinding binding = FragmentNoCodeBinding.inflate(inflater, container, false);
-        MobileAds.initialize(requireContext());
-        binding.adView.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.adView);
 
         String message = requireArguments().getString(ARG_MESSAGE, String.valueOf(R.string.no_java_code_needed));
         binding.textViewNoCodeMessage.setText(message);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/home/HomeFragment.java
@@ -14,8 +14,7 @@ import com.bumptech.glide.Glide;
 import com.d4rk.androidtutorials.java.data.model.PromotedApp;
 import com.d4rk.androidtutorials.java.databinding.FragmentHomeBinding;
 import com.d4rk.androidtutorials.java.utils.ConsentUtils;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import dagger.hilt.android.AndroidEntryPoint;
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
@@ -85,12 +84,10 @@ public class HomeFragment extends Fragment {
 
     private void initializeAds() {
         if (ConsentUtils.canShowAds(requireContext())) {
-            MobileAds.initialize(requireContext());
             binding.smallBannerAd.setVisibility(View.VISIBLE);
             binding.largeBannerAd.setVisibility(View.VISIBLE);
-            AdRequest request = new AdRequest.Builder().build();
-            binding.smallBannerAd.loadAd(request);
-            binding.largeBannerAd.loadAd(request);
+            AdUtils.loadBanner(binding.smallBannerAd);
+            AdUtils.loadBanner(binding.largeBannerAd);
         } else {
             binding.smallBannerAd.setVisibility(View.GONE);
             binding.largeBannerAd.setVisibility(View.GONE);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainActivity.java
@@ -42,8 +42,7 @@ import com.d4rk.androidtutorials.java.ui.screens.support.SupportActivity;
 import com.d4rk.androidtutorials.java.utils.ConsentUtils;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 import com.d4rk.androidtutorials.java.utils.ReviewHelper;
-import com.google.android.gms.ads.AdRequest;
-import com.google.android.gms.ads.MobileAds;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 import com.google.android.material.navigation.NavigationBarView;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.android.play.core.appupdate.AppUpdateInfo;
@@ -81,10 +80,9 @@ public class MainActivity extends AppCompatActivity {
             if (mBinding != null && mBinding.adView != null) {
                 if (ConsentUtils.canShowAds(MainActivity.this)) {
                     if (mBinding.adView.getVisibility() != View.VISIBLE) {
-                        MobileAds.initialize(MainActivity.this);
                         mBinding.adPlaceholder.setVisibility(View.GONE);
                         mBinding.adView.setVisibility(View.VISIBLE);
-                        mBinding.adView.loadAd(new AdRequest.Builder().build());
+                        AdUtils.loadBanner(mBinding.adView);
                     }
                 } else {
                     mBinding.adView.setVisibility(View.GONE);
@@ -204,10 +202,9 @@ public class MainActivity extends AppCompatActivity {
                 navBarView.setLabelVisibilityMode(uiState.bottomNavVisibility());
                 if (binding.adView != null) {
                     if (ConsentUtils.canShowAds(this)) {
-                        MobileAds.initialize(this);
                         binding.adPlaceholder.setVisibility(View.GONE);
                         binding.adView.setVisibility(View.VISIBLE);
-                        binding.adView.loadAd(new AdRequest.Builder().build());
+                        AdUtils.loadBanner(binding.adView);
                     } else {
                         binding.adView.setVisibility(View.GONE);
                         binding.adPlaceholder.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/support/SupportActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/support/SupportActivity.java
@@ -11,6 +11,7 @@ import com.d4rk.androidtutorials.java.data.repository.SupportRepository;
 import com.d4rk.androidtutorials.java.databinding.ActivitySupportBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.BaseActivity;
 import com.google.android.gms.ads.AdRequest;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.util.List;
 
@@ -30,9 +31,9 @@ public class SupportActivity extends BaseActivity {
 
         supportViewModel = new ViewModelProvider(this).get(SupportViewModel.class);
 
-        AdRequest adRequest = supportViewModel.initMobileAds();
-        binding.supportNativeAd.loadAd(adRequest);
-        binding.bannerAdView.loadAd(adRequest);
+        AdUtils.initialize(this);
+        binding.supportNativeAd.loadAd(new AdRequest.Builder().build());
+        AdUtils.loadBanner(binding.bannerAdView);
 
         binding.buttonWebAd.setOnClickListener(v ->
                 startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://bit.ly/3p8bpjj"))));


### PR DESCRIPTION
## Summary
- add `AdUtils` helper for one-time `MobileAds` init and banner loading
- refactor activities and fragments to load banner ads via `AdUtils`
- initialize Mobile Ads in `AppOpenAd` and support screen through `AdUtils`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d631b61c832d9872d257853b516c