### PR TITLE
Refactor up navigation handling

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -175,7 +175,7 @@
             android:name=".ui.screens.settings.screens.permissions.PermissionsActivity"
             android:exported="false"
             android:label="@string/permissions"
-            android:parentActivityName=".ui.screens.main.MainActivity" />
+            android:parentActivityName=".ui.screens.settings.SettingsActivity" />
         <activity
             android:name=".ui.screens.android.lessons.basics.shortcuts.ShortcutsActivity"
             android:exported="false"

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/navigation/UpNavigationActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/navigation/UpNavigationActivity.java
@@ -1,22 +1,8 @@
 package com.d4rk.androidtutorials.java.ui.components.navigation;
 
-import android.os.Bundle;
-
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.NavUtils;
 
-public abstract class UpNavigationActivity extends AppCompatActivity {
-    @Override
-    protected void onPostCreate(@Nullable Bundle savedInstanceState) {
-        super.onPostCreate(savedInstanceState);
-        ActionBar actionBar = getSupportActionBar();
-        if (actionBar != null) {
-            actionBar.setDisplayHomeAsUpEnabled(true);
-        }
-    }
-
+public abstract class UpNavigationActivity extends BaseActivity {
     @Override
     public boolean onSupportNavigateUp() {
         NavUtils.navigateUpFromSameTask(this);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/navigation/UpNavigationActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/navigation/UpNavigationActivity.java
@@ -1,11 +1,9 @@
 package com.d4rk.androidtutorials.java.ui.components.navigation;
 
-import androidx.core.app.NavUtils;
-
 public abstract class UpNavigationActivity extends BaseActivity {
     @Override
     public boolean onSupportNavigateUp() {
-        NavUtils.navigateUpFromSameTask(this);
+        getOnBackPressedDispatcher().onBackPressed();
         return true;
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/ShortcutsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/ShortcutsActivity.java
@@ -4,13 +4,11 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 
-import androidx.appcompat.app.ActionBar;
 import androidx.preference.PreferenceFragmentCompat;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivityShortcutsBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
-import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 public class ShortcutsActivity extends UpNavigationActivity {
@@ -20,12 +18,9 @@ public class ShortcutsActivity extends UpNavigationActivity {
         ActivityShortcutsBinding binding = ActivityShortcutsBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
-        EdgeToEdgeDelegate.apply(this, binding.container);        AdUtils.loadBanner(binding.adViewBottom);
+        AdUtils.loadBanner(binding.adViewBottom);
 
         getSupportFragmentManager().beginTransaction().replace(R.id.frame_layout_shortcuts, new SettingsFragment()).commit();
-        ActionBar supportActionBar = getSupportActionBar();
-        if (supportActionBar != null)
-            supportActionBar.setDisplayHomeAsUpEnabled(true);
         binding.buttonMore.setOnClickListener(v -> startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://developer.android.com/studio/intro/keyboard-shortcuts"))));
     }
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainActivity.java
@@ -160,7 +160,6 @@ public class MainActivity extends AppCompatActivity {
     private void setupActionBar() {
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
-            actionBar.setDisplayHomeAsUpEnabled(true);
             new AppBarConfiguration.Builder(
                     R.id.navigation_home,
                     R.id.navigation_android_studio,

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/settings/SettingsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/settings/SettingsActivity.java
@@ -4,19 +4,17 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.preference.ListPreference;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivitySettingsBinding;
-import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
+import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 
 import dagger.hilt.android.AndroidEntryPoint;
 
 @AndroidEntryPoint
-public class SettingsActivity extends AppCompatActivity
+public class SettingsActivity extends UpNavigationActivity
         implements SharedPreferences.OnSharedPreferenceChangeListener,
         androidx.preference.Preference.SummaryProvider<ListPreference> {
 
@@ -28,7 +26,6 @@ public class SettingsActivity extends AppCompatActivity
         ActivitySettingsBinding binding = ActivitySettingsBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
-        EdgeToEdgeDelegate.apply(this, binding.container);
 
         settingsViewModel = new ViewModelProvider(this).get(SettingsViewModel.class);
         settingsViewModel.applyConsent();
@@ -37,10 +34,6 @@ public class SettingsActivity extends AppCompatActivity
                 .replace(R.id.settings, new SettingsFragment())
                 .commit();
 
-        ActionBar supportActionBar = getSupportActionBar();
-        if (supportActionBar != null) {
-            supportActionBar.setDisplayHomeAsUpEnabled(true);
-        }
 
         settingsViewModel.registerPreferenceChangeListener(this);
     }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/settings/screens/permissions/PermissionsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/settings/screens/permissions/PermissionsActivity.java
@@ -7,7 +7,6 @@ import androidx.preference.PreferenceFragmentCompat;
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivityPermissionsBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
-import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 
 public class PermissionsActivity extends UpNavigationActivity {
     @Override
@@ -16,12 +15,7 @@ public class PermissionsActivity extends UpNavigationActivity {
         ActivityPermissionsBinding binding = ActivityPermissionsBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
-        EdgeToEdgeDelegate.apply(this, binding.container);
-
         getSupportFragmentManager().beginTransaction().replace(R.id.frame_layout_permissions, new SettingsFragment()).commit();
-        if (getSupportActionBar() != null) {
-            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-        }
     }
 
     public static class SettingsFragment extends PreferenceFragmentCompat {


### PR DESCRIPTION
## Summary
- centralize up navigation in base activity
- clean up settings and permissions activities
- remove duplicate home indicator calls

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5dd63e638832d9dcff9070d422214