### PR TITLE
refactor: unify TabCode fragments with generic ad base

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/NoCodeAdFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/NoCodeAdFragment.java
@@ -47,7 +47,7 @@ public abstract class NoCodeAdFragment<T extends ViewBinding> extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
                              @Nullable Bundle savedInstanceState) {
         binding = inflateBinding(inflater, container);
-        View adView = binding.getRoot().findViewById(R.id.adView);
+        View adView = binding.getRoot().findViewById(R.id.ad_view);
         AdUtils.loadBanner(adView);
         onBindingCreated(binding, savedInstanceState);
         return binding.getRoot();

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/NoCodeAdFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/NoCodeAdFragment.java
@@ -1,0 +1,61 @@
+package com.d4rk.androidtutorials.java.ui.components;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.viewbinding.ViewBinding;
+
+import com.d4rk.androidtutorials.java.R;
+import com.d4rk.androidtutorials.java.ads.AdUtils;
+
+/**
+ * Generic fragment that inflates a provided ViewBinding and loads a banner ad.
+ *
+ * @param <T> The type of ViewBinding associated with this fragment.
+ */
+public abstract class NoCodeAdFragment<T extends ViewBinding> extends Fragment {
+    protected T binding;
+
+    /**
+     * Inflate the ViewBinding for this fragment.
+     *
+     * @param inflater  LayoutInflater to use.
+     * @param container Optional container.
+     * @return The inflated binding.
+     */
+    @NonNull
+    protected abstract T inflateBinding(@NonNull LayoutInflater inflater, @Nullable ViewGroup container);
+
+    /**
+     * Called after the binding has been created and the banner ad loaded.
+     * Subclasses can override to perform additional setup.
+     *
+     * @param binding The binding instance.
+     * @param savedInstanceState Saved instance state.
+     */
+    protected void onBindingCreated(@NonNull T binding, @Nullable Bundle savedInstanceState) {
+        // default no-op
+    }
+
+    @Override
+    @NonNull
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        binding = inflateBinding(inflater, container);
+        View adView = binding.getRoot().findViewById(R.id.adView);
+        AdUtils.loadBanner(adView);
+        onBindingCreated(binding, savedInstanceState);
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+}

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/tabs/ButtonsTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/tabs/ButtonsTabCodeFragment.java
@@ -5,19 +5,17 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
 import androidx.preference.PreferenceManager;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.FragmentSameCodeBinding;
+import com.d4rk.androidtutorials.java.ui.components.NoCodeAdFragment;
 import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -26,13 +24,17 @@ import java.io.InputStreamReader;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class ButtonsTabCodeFragment extends Fragment {
+public class ButtonsTabCodeFragment extends NoCodeAdFragment<FragmentSameCodeBinding> {
 
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        FragmentSameCodeBinding binding = FragmentSameCodeBinding.inflate(inflater, container, false);
+    @NonNull
+    protected FragmentSameCodeBinding inflateBinding(@NonNull LayoutInflater inflater, ViewGroup container) {
+        return FragmentSameCodeBinding.inflate(inflater, container, false);
+    }
+
+    @Override
+    protected void onBindingCreated(@NonNull FragmentSameCodeBinding binding, Bundle savedInstanceState) {
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
-        AdUtils.loadBanner(binding.adView);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
@@ -51,7 +53,5 @@ public class ButtonsTabCodeFragment extends Fragment {
             Log.e("ButtonsTabCode", "Error reading code", e);
         }
         binding.textViewWarning.setText(R.string.same_code_buttons);
-        return binding.getRoot();
     }
-
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/clock/tabs/ClockTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/clock/tabs/ClockTabCodeFragment.java
@@ -1,21 +1,17 @@
 package com.d4rk.androidtutorials.java.ui.screens.android.lessons.clocks.clock.tabs;
 
-import android.os.Bundle;
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
 
 import com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding;
-import com.d4rk.androidtutorials.java.ads.AdUtils;
+import com.d4rk.androidtutorials.java.ui.components.NoCodeAdFragment;
 
-public class ClockTabCodeFragment extends Fragment {
+public class ClockTabCodeFragment extends NoCodeAdFragment<FragmentNoCodeBinding> {
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding binding = FragmentNoCodeBinding.inflate(inflater, container, false);
-        AdUtils.loadBanner(binding.adView);
-        return binding.getRoot();
+    @NonNull
+    protected FragmentNoCodeBinding inflateBinding(@NonNull LayoutInflater inflater, ViewGroup container) {
+        return FragmentNoCodeBinding.inflate(inflater, container, false);
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/data/room/tabs/RoomTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/data/room/tabs/RoomTabCodeFragment.java
@@ -5,19 +5,17 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
 import androidx.preference.PreferenceManager;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.FragmentCodeBinding;
+import com.d4rk.androidtutorials.java.ui.components.NoCodeAdFragment;
 import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -29,13 +27,17 @@ import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 /**
  * Shows the Java implementation for the Room example.
  */
-public class RoomTabCodeFragment extends Fragment {
+public class RoomTabCodeFragment extends NoCodeAdFragment<FragmentCodeBinding> {
 
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        FragmentCodeBinding binding = FragmentCodeBinding.inflate(inflater, container, false);
+    @NonNull
+    protected FragmentCodeBinding inflateBinding(@NonNull LayoutInflater inflater, ViewGroup container) {
+        return FragmentCodeBinding.inflate(inflater, container, false);
+    }
+
+    @Override
+    protected void onBindingCreated(@NonNull FragmentCodeBinding binding, Bundle savedInstanceState) {
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
-        AdUtils.loadBanner(binding.adView);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
@@ -53,7 +55,6 @@ public class RoomTabCodeFragment extends Fragment {
         } catch (IOException e) {
             Log.e("RoomTabCode", "Error reading code", e);
         }
-        return binding.getRoot();
     }
 }
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/linear/tabs/LinearLayoutTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/linear/tabs/LinearLayoutTabCodeFragment.java
@@ -1,21 +1,17 @@
 package com.d4rk.androidtutorials.java.ui.screens.android.lessons.layouts.linear.tabs;
 
-import android.os.Bundle;
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
 
 import com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding;
-import com.d4rk.androidtutorials.java.ads.AdUtils;
+import com.d4rk.androidtutorials.java.ui.components.NoCodeAdFragment;
 
-public class LinearLayoutTabCodeFragment extends Fragment {
+public class LinearLayoutTabCodeFragment extends NoCodeAdFragment<FragmentNoCodeBinding> {
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding binding = FragmentNoCodeBinding.inflate(inflater, container, false);
-        AdUtils.loadBanner(binding.adView);
-        return binding.getRoot();
+    @NonNull
+    protected FragmentNoCodeBinding inflateBinding(@NonNull LayoutInflater inflater, ViewGroup container) {
+        return FragmentNoCodeBinding.inflate(inflater, container, false);
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/relative/tabs/RelativeLayoutTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/relative/tabs/RelativeLayoutTabCodeFragment.java
@@ -1,21 +1,17 @@
 package com.d4rk.androidtutorials.java.ui.screens.android.lessons.layouts.relative.tabs;
 
-import android.os.Bundle;
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
 
 import com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding;
-import com.d4rk.androidtutorials.java.ads.AdUtils;
+import com.d4rk.androidtutorials.java.ui.components.NoCodeAdFragment;
 
-public class RelativeLayoutTabCodeFragment extends Fragment {
+public class RelativeLayoutTabCodeFragment extends NoCodeAdFragment<FragmentNoCodeBinding> {
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding binding = FragmentNoCodeBinding.inflate(inflater, container, false);
-        AdUtils.loadBanner(binding.adView);
-        return binding.getRoot();
+    @NonNull
+    protected FragmentNoCodeBinding inflateBinding(@NonNull LayoutInflater inflater, ViewGroup container) {
+        return FragmentNoCodeBinding.inflate(inflater, container, false);
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/table/tabs/TableLayoutTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/table/tabs/TableLayoutTabCodeFragment.java
@@ -1,21 +1,17 @@
 package com.d4rk.androidtutorials.java.ui.screens.android.lessons.layouts.table.tabs;
 
-import android.os.Bundle;
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
 
 import com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding;
-import com.d4rk.androidtutorials.java.ads.AdUtils;
+import com.d4rk.androidtutorials.java.ui.components.NoCodeAdFragment;
 
-public class TableLayoutTabCodeFragment extends Fragment {
+public class TableLayoutTabCodeFragment extends NoCodeAdFragment<FragmentNoCodeBinding> {
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding binding = FragmentNoCodeBinding.inflate(inflater, container, false);
-        AdUtils.loadBanner(binding.adView);
-        return binding.getRoot();
+    @NonNull
+    protected FragmentNoCodeBinding inflateBinding(@NonNull LayoutInflater inflater, ViewGroup container) {
+        return FragmentNoCodeBinding.inflate(inflater, container, false);
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/networking/retrofit/tabs/RetrofitTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/networking/retrofit/tabs/RetrofitTabCodeFragment.java
@@ -5,19 +5,17 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
 import androidx.preference.PreferenceManager;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.FragmentCodeBinding;
+import com.d4rk.androidtutorials.java.ui.components.NoCodeAdFragment;
 import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -29,13 +27,17 @@ import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 /**
  * Shows the Java implementation for the Retrofit example.
  */
-public class RetrofitTabCodeFragment extends Fragment {
+public class RetrofitTabCodeFragment extends NoCodeAdFragment<FragmentCodeBinding> {
 
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        FragmentCodeBinding binding = FragmentCodeBinding.inflate(inflater, container, false);
+    @NonNull
+    protected FragmentCodeBinding inflateBinding(@NonNull LayoutInflater inflater, ViewGroup container) {
+        return FragmentCodeBinding.inflate(inflater, container, false);
+    }
+
+    @Override
+    protected void onBindingCreated(@NonNull FragmentCodeBinding binding, Bundle savedInstanceState) {
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
-        AdUtils.loadBanner(binding.adView);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
@@ -53,6 +55,5 @@ public class RetrofitTabCodeFragment extends Fragment {
         } catch (IOException e) {
             Log.e("RetrofitTabCode", "Error reading code", e);
         }
-        return binding.getRoot();
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/progress/progressbar/tabs/ProgressBarTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/progress/progressbar/tabs/ProgressBarTabCodeFragment.java
@@ -5,19 +5,17 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
 import androidx.preference.PreferenceManager;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.FragmentCodeBinding;
+import com.d4rk.androidtutorials.java.ui.components.NoCodeAdFragment;
 import com.d4rk.androidtutorials.java.utils.CodeHighlighter;
 import com.d4rk.androidtutorials.java.utils.CodeViewUtils;
 import com.d4rk.androidtutorials.java.utils.FontManager;
-import com.d4rk.androidtutorials.java.ads.AdUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -26,13 +24,17 @@ import java.io.InputStreamReader;
 
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
 
-public class ProgressBarTabCodeFragment extends Fragment {
+public class ProgressBarTabCodeFragment extends NoCodeAdFragment<FragmentCodeBinding> {
 
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        FragmentCodeBinding binding = FragmentCodeBinding.inflate(inflater, container, false);
+    @NonNull
+    protected FragmentCodeBinding inflateBinding(@NonNull LayoutInflater inflater, ViewGroup container) {
+        return FragmentCodeBinding.inflate(inflater, container, false);
+    }
+
+    @Override
+    protected void onBindingCreated(@NonNull FragmentCodeBinding binding, Bundle savedInstanceState) {
         new FastScrollerBuilder(binding.scrollView).useMd2Style().build();
-        AdUtils.loadBanner(binding.adView);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         Typeface monospaceFont = FontManager.getMonospaceFont(requireContext(), prefs);
@@ -50,7 +52,5 @@ public class ProgressBarTabCodeFragment extends Fragment {
         } catch (IOException e) {
             Log.e("ProgressBarTabCode", "Error reading code", e);
         }
-        return binding.getRoot();
     }
-
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/images/tabs/ImagesTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/images/tabs/ImagesTabCodeFragment.java
@@ -1,21 +1,17 @@
 package com.d4rk.androidtutorials.java.ui.screens.android.lessons.views.images.tabs;
 
-import android.os.Bundle;
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
 
 import com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding;
-import com.d4rk.androidtutorials.java.ads.AdUtils;
+import com.d4rk.androidtutorials.java.ui.components.NoCodeAdFragment;
 
-public class ImagesTabCodeFragment extends Fragment {
+public class ImagesTabCodeFragment extends NoCodeAdFragment<FragmentNoCodeBinding> {
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        com.d4rk.androidtutorials.java.databinding.FragmentNoCodeBinding binding = FragmentNoCodeBinding.inflate(inflater, container, false);
-        AdUtils.loadBanner(binding.adView);
-        return binding.getRoot();
+    @NonNull
+    protected FragmentNoCodeBinding inflateBinding(@NonNull LayoutInflater inflater, ViewGroup container) {
+        return FragmentNoCodeBinding.inflate(inflater, container, false);
     }
 }


### PR DESCRIPTION
## Summary
- add `NoCodeAdFragment` to inflate bindings and load banner ads
- refactor TabCode fragments to extend the new base

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e18cf65c832d9d792a775f0606c4