### PR TITLE
docs: fix help screen and clarify lifecycle guidance

### DIFF
--- a/docs/core/android-architecture-recommendations.md
+++ b/docs/core/android-architecture-recommendations.md
@@ -39,7 +39,7 @@ point of user interaction. Here are some best practices for the UI layer:
 |--------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
 | **Follow Unidirectional Data Flow (UDF).**<br/>Strongly recommended                  | Follow UDF principles, where ViewModels expose UI state using the observer pattern and receive actions from the UI through method calls. |
 | **Use AAC ViewModels if their benefits apply to your app.**<br/>Strongly recommended | Use AndroidX ViewModels to handle business logic and fetch application data to expose UI state to the UI.                                |
-| **Use lifecycle-aware UI state collection.**<br/>Strongly recommended                | Collect UI state from the UI using lifecycle-aware APIs such as `repeatOnLifecycle`.                                                     |
+| **Use lifecycle-aware UI state collection.**<br/>Strongly recommended                | Observe `LiveData` with a `LifecycleOwner` (for example, `getViewLifecycleOwner()` in Fragments) so updates stop automatically when the UI is stopped. |
 | **Do not send events from the ViewModel to the UI.**<br/>Strongly recommended        | Process the event immediately in the ViewModel and cause a state update with the result of handling the event.                           |
 | **Use a single-activity application.**<br/>Recommended                               | Use Navigation Fragments to navigate between screens and deep link to your app if your app has more than one screen.                     |
 

--- a/docs/screens/help.md
+++ b/docs/screens/help.md
@@ -20,14 +20,6 @@ The Help screen offers the following functionalities, accessible primarily throu
 -   **Privacy Policy**: Opens a web link to the app's Privacy Policy.
 -   **Open Source Licenses**: Displays a screen with a list of open-source libraries used in the app and their licenses.
 
-## Ads
-The Help page displays a single native ad between the FAQ list and the Contact Us card.
-The banner is rendered by `HelpNativeAdBanner` which uses the shared `native_ad` configuration.
-An **Ad** label is shown to comply with policy requirements and padding ensures the banner
-does not interfere with surrounding content.
-See [Ads](settings/privacy/ads.md) for more information on ad configuration.
-*(Note: Presence of ads should be confirmed by checking layout files like `activity_help.xml`)*
-
 ## Integration
 To launch the Help screen, use the following Java code:
 ```java


### PR DESCRIPTION
## Summary
- remove outdated ad references from Help screen docs
- clarify lifecycle-aware UI observation for Java in architecture guide

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f15811a4832d878cbf3c8410f0c6