### PR TITLE
test: add DefaultHomeLocalDataSource tests

### DIFF
--- a/app/src/test/java/com/d4rk/androidtutorials/java/data/source/DefaultHomeLocalDataSourceTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/data/source/DefaultHomeLocalDataSourceTest.java
@@ -1,0 +1,48 @@
+package com.d4rk.androidtutorials.java.data.source;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.content.res.Resources;
+
+import com.d4rk.androidtutorials.java.R;
+
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+public class DefaultHomeLocalDataSourceTest {
+
+    @Test
+    public void playStoreUrlsFormattedCorrectly() {
+        DefaultHomeLocalDataSource dataSource =
+                new DefaultHomeLocalDataSource(mockContextWithTips(new String[]{"tip"}));
+        assertEquals("https://play.google.com/store/apps/details?id=com.d4rk.androidtutorials", dataSource.getPlayStoreUrl());
+        assertEquals("https://play.google.com/store/apps/details?id=pkg", dataSource.getAppPlayStoreUrl("pkg"));
+    }
+
+    @Test
+    public void dailyTipUsesEpochDayIndex() {
+        Context context = mockContextWithTips(new String[]{"tip1", "tip2", "tip3"});
+        DefaultHomeLocalDataSource dataSource = new DefaultHomeLocalDataSource(context);
+
+        long days = 5L; // 5 days since epoch -> index = 2
+        long millis = days * 24L * 60L * 60L * 1000L;
+
+        try (MockedStatic<System> mocked = mockStatic(System.class)) {
+            mocked.when(System::currentTimeMillis).thenReturn(millis);
+            assertEquals("tip3", dataSource.getDailyTip());
+        }
+    }
+
+    private static Context mockContextWithTips(String[] tips) {
+        Context context = mock(Context.class);
+        Resources resources = mock(Resources.class);
+        when(context.getApplicationContext()).thenReturn(context);
+        when(context.getResources()).thenReturn(resources);
+        when(resources.getStringArray(R.array.daily_tips)).thenReturn(tips);
+        return context;
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/data/source/DefaultHomeLocalDataSourceTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/data/source/DefaultHomeLocalDataSourceTest.java
@@ -2,7 +2,6 @@ package com.d4rk.androidtutorials.java.data.source;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;
@@ -11,7 +10,6 @@ import android.content.res.Resources;
 import com.d4rk.androidtutorials.java.R;
 
 import org.junit.Test;
-import org.mockito.MockedStatic;
 
 public class DefaultHomeLocalDataSourceTest {
 
@@ -25,16 +23,13 @@ public class DefaultHomeLocalDataSourceTest {
 
     @Test
     public void dailyTipUsesEpochDayIndex() {
-        Context context = mockContextWithTips(new String[]{"tip1", "tip2", "tip3"});
+        String[] tips = {"tip1", "tip2", "tip3"};
+        Context context = mockContextWithTips(tips);
         DefaultHomeLocalDataSource dataSource = new DefaultHomeLocalDataSource(context);
 
-        long days = 5L; // 5 days since epoch -> index = 2
-        long millis = days * 24L * 60L * 60L * 1000L;
-
-        try (MockedStatic<System> mocked = mockStatic(System.class)) {
-            mocked.when(System::currentTimeMillis).thenReturn(millis);
-            assertEquals("tip3", dataSource.getDailyTip());
-        }
+        long daysSinceEpoch = System.currentTimeMillis() / (24L * 60L * 60L * 1000L);
+        int expectedIndex = (int) (daysSinceEpoch % tips.length);
+        assertEquals(tips[expectedIndex], dataSource.getDailyTip());
     }
 
     private static Context mockContextWithTips(String[] tips) {


### PR DESCRIPTION
## Summary
- add unit tests for DefaultHomeLocalDataSource

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f7922350832da67d366f57d6b3f8