### PR TITLE
test: add remote data source parsing tests

### DIFF
--- a/app/src/test/java/com/d4rk/androidtutorials/java/data/source/DefaultHomeRemoteDataSourceTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/data/source/DefaultHomeRemoteDataSourceTest.java
@@ -1,0 +1,62 @@
+package com.d4rk.androidtutorials.java.data.source;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import android.os.Looper;
+
+import com.android.volley.RequestQueue;
+import com.d4rk.androidtutorials.java.data.model.PromotedApp;
+
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+public class DefaultHomeRemoteDataSourceTest {
+
+    private DefaultHomeRemoteDataSource dataSource;
+    private Method parseMethod;
+
+    @Before
+    public void setUp() throws Exception {
+        if (Looper.getMainLooper() == null) {
+            try {
+                Method prepareMainLooper = Looper.class.getDeclaredMethod("prepareMainLooper");
+                prepareMainLooper.setAccessible(true);
+                prepareMainLooper.invoke(null);
+            } catch (Exception ignored) {
+                Looper.prepare();
+            }
+        }
+        RequestQueue queue = mock(RequestQueue.class);
+        dataSource = new DefaultHomeRemoteDataSource(queue, "https://example.com");
+        parseMethod = DefaultHomeRemoteDataSource.class.getDeclaredMethod("parseResponse", JSONObject.class);
+        parseMethod.setAccessible(true);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<PromotedApp> invokeParse(JSONObject json) throws Exception {
+        return (List<PromotedApp>) parseMethod.invoke(dataSource, json);
+    }
+
+    @Test
+    public void parseResponseFiltersOwnPackages() throws Exception {
+        String json = "{\"data\":{\"apps\":[" +
+                "{\"name\":\"App1\",\"packageName\":\"com.example.app1\",\"iconLogo\":\"logo1\"}," +
+                "{\"name\":\"App2\",\"packageName\":\"com.d4rk.androidtutorials.sample\",\"iconLogo\":\"logo2\"}]}}";
+        List<PromotedApp> result = invokeParse(new JSONObject(json));
+        assertEquals(1, result.size());
+        assertEquals("com.example.app1", result.get(0).getPackageName());
+    }
+
+    @Test
+    public void parseResponseMalformedJsonReturnsEmptyList() throws Exception {
+        String json = "{\"data\":{}}";
+        List<PromotedApp> result = invokeParse(new JSONObject(json));
+        assertTrue(result.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for DefaultHomeRemoteDataSource JSON parsing
- verify own package entries are filtered and malformed data returns empty list

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c66132851c832d8e8c59ab5eb04e67