### PR TITLE
test: add home domain use case tests

### DIFF
--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/home/GetAppPlayStoreUrlUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/home/GetAppPlayStoreUrlUseCaseTest.java
@@ -1,0 +1,25 @@
+package com.d4rk.androidtutorials.java.domain.home;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.d4rk.androidtutorials.java.data.repository.HomeRepository;
+
+import org.junit.Test;
+
+public class GetAppPlayStoreUrlUseCaseTest {
+
+    @Test
+    public void invokeReturnsAppUrl() {
+        HomeRepository repository = mock(HomeRepository.class);
+        when(repository.getAppPlayStoreUrl("pkg")).thenReturn("url");
+        GetAppPlayStoreUrlUseCase useCase = new GetAppPlayStoreUrlUseCase(repository);
+
+        String result = useCase.invoke("pkg");
+
+        assertEquals("url", result);
+        verify(repository).getAppPlayStoreUrl("pkg");
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/home/GetDailyTipUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/home/GetDailyTipUseCaseTest.java
@@ -1,0 +1,25 @@
+package com.d4rk.androidtutorials.java.domain.home;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.d4rk.androidtutorials.java.data.repository.HomeRepository;
+
+import org.junit.Test;
+
+public class GetDailyTipUseCaseTest {
+
+    @Test
+    public void invokeReturnsDailyTip() {
+        HomeRepository repository = mock(HomeRepository.class);
+        when(repository.dailyTip()).thenReturn("tip");
+        GetDailyTipUseCase useCase = new GetDailyTipUseCase(repository);
+
+        String result = useCase.invoke();
+
+        assertEquals("tip", result);
+        verify(repository).dailyTip();
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/home/GetPlayStoreUrlUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/home/GetPlayStoreUrlUseCaseTest.java
@@ -1,0 +1,25 @@
+package com.d4rk.androidtutorials.java.domain.home;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.d4rk.androidtutorials.java.data.repository.HomeRepository;
+
+import org.junit.Test;
+
+public class GetPlayStoreUrlUseCaseTest {
+
+    @Test
+    public void invokeReturnsUrl() {
+        HomeRepository repository = mock(HomeRepository.class);
+        when(repository.getPlayStoreUrl()).thenReturn("url");
+        GetPlayStoreUrlUseCase useCase = new GetPlayStoreUrlUseCase(repository);
+
+        String result = useCase.invoke();
+
+        assertEquals("url", result);
+        verify(repository).getPlayStoreUrl();
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/home/GetPromotedAppsUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/home/GetPromotedAppsUseCaseTest.java
@@ -1,0 +1,44 @@
+package com.d4rk.androidtutorials.java.domain.home;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.d4rk.androidtutorials.java.data.model.PromotedApp;
+import com.d4rk.androidtutorials.java.data.repository.HomeRepository;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+public class GetPromotedAppsUseCaseTest {
+
+    @Test
+    public void invokeCallsRepository() {
+        HomeRepository repository = mock(HomeRepository.class);
+        GetPromotedAppsUseCase useCase = new GetPromotedAppsUseCase(repository);
+
+        useCase.invoke(apps -> {});
+
+        verify(repository).fetchPromotedApps(any());
+    }
+
+    @Test
+    public void invokeReturnsAppsThroughCallback() {
+        HomeRepository repository = mock(HomeRepository.class);
+        GetPromotedAppsUseCase useCase = new GetPromotedAppsUseCase(repository);
+        GetPromotedAppsUseCase.Callback callback = mock(GetPromotedAppsUseCase.Callback.class);
+
+        useCase.invoke(callback);
+
+        ArgumentCaptor<HomeRepository.PromotedAppsCallback> captor =
+                ArgumentCaptor.forClass(HomeRepository.PromotedAppsCallback.class);
+        verify(repository).fetchPromotedApps(captor.capture());
+
+        List<PromotedApp> apps = List.of(new PromotedApp("App", "pkg", "icon"));
+        captor.getValue().onResult(apps);
+
+        verify(callback).onResult(apps);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for daily tip and Play Store URL use cases
- verify promoted apps use case invokes repository and propagates results

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c667a1c904832da7724da2b67dcdd2