### PR TITLE
test: add ReviewHelper unit tests

### DIFF
--- a/app/src/test/java/com/d4rk/androidtutorials/java/utils/ReviewHelperTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/utils/ReviewHelperTest.java
@@ -1,0 +1,93 @@
+package com.d4rk.androidtutorials.java.utils;
+
+import android.app.Activity;
+
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
+import com.google.android.play.core.review.ReviewInfo;
+import com.google.android.play.core.review.ReviewManager;
+import com.google.android.play.core.review.ReviewManagerFactory;
+
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link ReviewHelper}.
+ */
+public class ReviewHelperTest {
+
+    @Test
+    public void launchInAppReviewIfEligible_doesNothingWhenSessionCountLessThanThree() {
+        Activity activity = mock(Activity.class);
+        Runnable callback = mock(Runnable.class);
+
+        try (MockedStatic<ReviewManagerFactory> factory = mockStatic(ReviewManagerFactory.class)) {
+            ReviewHelper.launchInAppReviewIfEligible(activity, 2, false, callback);
+
+            factory.verifyNoInteractions();
+            verifyNoInteractions(callback);
+        }
+    }
+
+    @Test
+    public void launchInAppReviewIfEligible_doesNothingWhenPromptedBefore() {
+        Activity activity = mock(Activity.class);
+        Runnable callback = mock(Runnable.class);
+
+        try (MockedStatic<ReviewManagerFactory> factory = mockStatic(ReviewManagerFactory.class)) {
+            ReviewHelper.launchInAppReviewIfEligible(activity, 5, true, callback);
+
+            factory.verifyNoInteractions();
+            verifyNoInteractions(callback);
+        }
+    }
+
+    @Test
+    public void launchInAppReviewIfEligible_launchesReviewWhenEligible() {
+        Activity activity = mock(Activity.class);
+        Runnable callback = mock(Runnable.class);
+        ReviewManager reviewManager = mock(ReviewManager.class);
+        ReviewInfo reviewInfo = mock(ReviewInfo.class);
+
+        Task<ReviewInfo> requestTask = Tasks.forResult(reviewInfo);
+        Task<Void> launchTask = Tasks.forResult(null);
+
+        when(reviewManager.requestReviewFlow()).thenReturn(requestTask);
+        when(reviewManager.launchReviewFlow(activity, reviewInfo)).thenReturn(launchTask);
+
+        try (MockedStatic<ReviewManagerFactory> factory = mockStatic(ReviewManagerFactory.class)) {
+            factory.when(() -> ReviewManagerFactory.create(activity)).thenReturn(reviewManager);
+
+            ReviewHelper.launchInAppReviewIfEligible(activity, 3, false, callback);
+
+            factory.verify(() -> ReviewManagerFactory.create(activity));
+            verify(reviewManager).launchReviewFlow(activity, reviewInfo);
+            verify(callback).run();
+        }
+    }
+
+    @Test
+    public void forceLaunchInAppReview_alwaysTriggersLaunch() {
+        Activity activity = mock(Activity.class);
+        ReviewManager reviewManager = mock(ReviewManager.class);
+        ReviewInfo reviewInfo = mock(ReviewInfo.class);
+
+        Task<ReviewInfo> requestTask = Tasks.forResult(reviewInfo);
+        Task<Void> launchTask = Tasks.forResult(null);
+
+        when(reviewManager.requestReviewFlow()).thenReturn(requestTask);
+        when(reviewManager.launchReviewFlow(activity, reviewInfo)).thenReturn(launchTask);
+
+        try (MockedStatic<ReviewManagerFactory> factory = mockStatic(ReviewManagerFactory.class)) {
+            factory.when(() -> ReviewManagerFactory.create(activity)).thenReturn(reviewManager);
+
+            ReviewHelper.forceLaunchInAppReview(activity);
+
+            factory.verify(() -> ReviewManagerFactory.create(activity));
+            verify(reviewManager).launchReviewFlow(activity, reviewInfo);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit tests covering ReviewHelper logic

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c669a808b8832db1fc827033c5b78b