### PR TITLE
test: verify CodeViewUtils defaults

### DIFF
--- a/app/src/test/java/com/d4rk/androidtutorials/java/utils/CodeViewUtilsTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/utils/CodeViewUtilsTest.java
@@ -1,0 +1,40 @@
+package com.d4rk.androidtutorials.java.utils;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import android.graphics.Typeface;
+
+import com.amrdeveloper.codeview.CodeView;
+
+import org.junit.Test;
+
+public class CodeViewUtilsTest {
+
+    private void verifyDefaults(CodeView view, Typeface typeface) {
+        verify(view).setTypeface(typeface);
+        verify(view).setTextSize(14f);
+        verify(view).setLineNumberTextSize(14f);
+        verify(view).setEnableLineNumber(false);
+        verify(view).setHorizontallyScrolling(false);
+        verify(view).setKeyListener(null);
+        verify(view).setCursorVisible(false);
+        verify(view).setTextIsSelectable(true);
+        verify(view).setHorizontalScrollBarEnabled(false);
+        verify(view).setVerticalScrollBarEnabled(false);
+        verify(view).setBackground(null);
+    }
+
+    @Test
+    public void applyDefaults_configuresAllViews() {
+        Typeface typeface = mock(Typeface.class);
+        CodeView first = mock(CodeView.class);
+        CodeView second = mock(CodeView.class);
+
+        CodeViewUtils.applyDefaults(typeface, first, second, null);
+
+        verifyDefaults(first, typeface);
+        verifyDefaults(second, typeface);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit test for CodeViewUtils ensuring defaults applied to multiple CodeView instances and ignoring nulls

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c66bad3584832dab9692f7a6910570