### PR TITLE
Add GetLessonUseCase unit test

### DIFF
--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/android/GetLessonUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/android/GetLessonUseCaseTest.java
@@ -1,0 +1,27 @@
+package com.d4rk.androidtutorials.java.domain.android;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.d4rk.androidtutorials.java.data.repository.LessonRepository;
+
+import org.junit.Test;
+
+public class GetLessonUseCaseTest {
+
+    @Test
+    public void invokeReturnsLesson() {
+        LessonRepository repository = mock(LessonRepository.class);
+        LessonRepository.Lesson lesson = new LessonRepository.Lesson(1, 2, 3);
+        when(repository.getLesson("intro")).thenReturn(lesson);
+        GetLessonUseCase useCase = new GetLessonUseCase(repository);
+
+        LessonRepository.Lesson result = useCase.invoke("intro");
+
+        assertSame(lesson, result);
+        verify(repository).getLesson("intro");
+    }
+}
+


### PR DESCRIPTION
## Summary
- test that GetLessonUseCase delegates to LessonRepository

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67a768c9c832db0b86f206acd783a