### PR TITLE
Defer ad and cookie initialization to background worker

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ads/managers/AppOpenAd.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ads/managers/AppOpenAd.java
@@ -5,7 +5,6 @@ import android.app.Application;
 import android.app.Application.ActivityLifecycleCallbacks;
 import android.content.Context;
 import android.os.Bundle;
-import android.webkit.CookieManager;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -35,8 +34,6 @@ public class AppOpenAd extends Application implements ActivityLifecycleCallbacks
     public void onCreate() {
         super.onCreate();
         registerActivityLifecycleCallbacks(this);
-        AdUtils.initialize(this);
-        CookieManager.getInstance();
         ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
         appOpenAdManager = new AppOpenAdManager(this);
     }
@@ -98,6 +95,7 @@ public class AppOpenAd extends Application implements ActivityLifecycleCallbacks
         }
 
         private void loadAd(Context context) {
+            AdUtils.initialize(context);
             if (isLoadingAd || isAdAvailable()) {
                 return;
             }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/startup/StartupInitializer.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/startup/StartupInitializer.java
@@ -1,0 +1,33 @@
+package com.d4rk.androidtutorials.java.startup;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.work.ExistingWorkPolicy;
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.WorkManager;
+
+/**
+ * Helper used to enqueue a one-off background job for initializing ads and
+ * cookies. The work is only scheduled once per app launch sequence.
+ */
+public final class StartupInitializer {
+
+    private static final String WORK_NAME = "startup_init";
+
+    private StartupInitializer() {
+        // no-op
+    }
+
+    /**
+     * Schedules the {@link StartupWorker} using {@link WorkManager}. If the work
+     * is already enqueued, this call is ignored.
+     */
+    public static void schedule(@NonNull Context context) {
+        OneTimeWorkRequest workRequest = new OneTimeWorkRequest.Builder(
+                StartupWorker.class).build();
+        WorkManager.getInstance(context).enqueueUniqueWork(
+                WORK_NAME, ExistingWorkPolicy.KEEP, workRequest);
+    }
+}
+

--- a/app/src/main/java/com/d4rk/androidtutorials/java/startup/StartupWorker.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/startup/StartupWorker.java
@@ -1,0 +1,30 @@
+package com.d4rk.androidtutorials.java.startup;
+
+import android.content.Context;
+import android.webkit.CookieManager;
+
+import androidx.annotation.NonNull;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+import com.d4rk.androidtutorials.java.ads.AdUtils;
+
+/**
+ * Background worker that initializes advertising utilities and the
+ * {@link CookieManager} away from the app's startup path.
+ */
+public class StartupWorker extends Worker {
+
+    public StartupWorker(@NonNull Context context, @NonNull WorkerParameters params) {
+        super(context, params);
+    }
+
+    @NonNull
+    @Override
+    public Result doWork() {
+        AdUtils.initialize(getApplicationContext());
+        CookieManager.getInstance();
+        return Result.success();
+    }
+}
+

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainActivity.java
@@ -44,6 +44,7 @@ import com.d4rk.androidtutorials.java.utils.ConsentUtils;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 import com.d4rk.androidtutorials.java.utils.ReviewHelper;
 import com.d4rk.androidtutorials.java.ads.AdUtils;
+import com.d4rk.androidtutorials.java.startup.StartupInitializer;
 import com.google.android.material.navigation.NavigationBarView;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.android.play.core.appupdate.AppUpdateInfo;
@@ -111,6 +112,8 @@ public class MainActivity extends AppCompatActivity {
         }
         mBinding = ActivityMainBinding.inflate(getLayoutInflater());
         setContentView(mBinding.getRoot());
+
+        StartupInitializer.schedule(this);
 
         mainViewModel = new ViewModelProvider(this).get(MainViewModel.class);
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/startup/StartupActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/startup/StartupActivity.java
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModelProvider;
 import com.d4rk.androidtutorials.java.databinding.ActivityStartupBinding;
 import com.d4rk.androidtutorials.java.ui.screens.onboarding.OnboardingActivity;
 import com.google.android.ump.ConsentRequestParameters;
+import com.d4rk.androidtutorials.java.startup.StartupInitializer;
 
 import dagger.hilt.android.AndroidEntryPoint;
 import me.zhanghai.android.fastscroll.FastScrollerBuilder;
@@ -24,6 +25,8 @@ public class StartupActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         ActivityStartupBinding binding = ActivityStartupBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        StartupInitializer.schedule(this);
 
         viewModel = new ViewModelProvider(this).get(StartupViewModel.class);
         ConsentRequestParameters params = new ConsentRequestParameters.Builder().build();


### PR DESCRIPTION
## Summary
- Add StartupWorker and StartupInitializer to initialize ads and cookies off the main thread
- Schedule background initialization from StartupActivity and MainActivity
- Load app-open ads with lazy MobileAds setup

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67e7ea070832db19196f6675a8f83