### PR TITLE
Add Robolectric tests for edge-to-edge delegate

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,6 +105,7 @@ dependencies {
     // Testing
     testImplementation libs.junit
     testImplementation libs.androidx.core.testing
+    testImplementation libs.robolectric
     testImplementation libs.mockito.core
     testImplementation libs.mockito.inline
 }

--- a/app/src/test/java/com/d4rk/androidtutorials/java/utils/EdgeToEdgeDelegateTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/utils/EdgeToEdgeDelegateTest.java
@@ -1,0 +1,65 @@
+package com.d4rk.androidtutorials.java.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import android.app.Activity;
+import android.view.View;
+
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class EdgeToEdgeDelegateTest {
+
+    @Test
+    public void apply_setsContainerPaddingToSystemBarInsets() {
+        Activity activity = Robolectric.buildActivity(Activity.class).setup().get();
+        View container = new View(activity);
+
+        EdgeToEdgeDelegate.apply(activity, container);
+
+        Insets bars = Insets.of(4, 8, 12, 16);
+        WindowInsetsCompat windowInsets = new WindowInsetsCompat.Builder()
+                .setInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout(), bars)
+                .build();
+
+        ViewCompat.dispatchApplyWindowInsets(container, windowInsets);
+
+        assertEquals(bars.left, container.getPaddingLeft());
+        assertEquals(bars.top, container.getPaddingTop());
+        assertEquals(bars.right, container.getPaddingRight());
+        assertEquals(bars.bottom, container.getPaddingBottom());
+    }
+
+    @Test
+    public void applyBottomBar_setsContainerTopPaddingAndBottomBarPadding() {
+        Activity activity = Robolectric.buildActivity(Activity.class).setup().get();
+        View container = new View(activity);
+        View bottomBar = new View(activity);
+
+        EdgeToEdgeDelegate.applyBottomBar(activity, container, bottomBar);
+
+        Insets bars = Insets.of(3, 6, 9, 12);
+        WindowInsetsCompat windowInsets = new WindowInsetsCompat.Builder()
+                .setInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout(), bars)
+                .build();
+
+        ViewCompat.dispatchApplyWindowInsets(container, windowInsets);
+
+        assertEquals(bars.left, container.getPaddingLeft());
+        assertEquals(bars.top, container.getPaddingTop());
+        assertEquals(bars.right, container.getPaddingRight());
+        assertEquals(0, container.getPaddingBottom());
+
+        assertEquals(0, bottomBar.getPaddingLeft());
+        assertEquals(0, bottomBar.getPaddingTop());
+        assertEquals(0, bottomBar.getPaddingRight());
+        assertEquals(bars.bottom, bottomBar.getPaddingBottom());
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ lifecycle = "2.9.3"
 lottie = "6.6.7"
 mockitoCore = "5.19.0"
 mockitoInline = "5.2.0"
+robolectric = "4.12.2"
 navigationUi = "2.9.4"
 preference = "1.2.1"
 review = "2.0.2"
@@ -61,6 +62,7 @@ material = { module = "com.google.android.material:material", version.ref = "mat
 materialratingbar-library = { module = "me.zhanghai.android.materialratingbar:library", version.ref = "libraryVersion" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore" }
 mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInline" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 play-services-ads = { module = "com.google.android.gms:play-services-ads", version.ref = "playServicesAds" }
 review = { module = "com.google.android.play:review", version.ref = "review" }
 volley = { module = "com.android.volley:volley", version.ref = "volley" }


### PR DESCRIPTION
## Summary
- add the Robolectric testing dependency to the unit test configuration
- cover EdgeToEdgeDelegate with Robolectric tests that verify container and bottom bar padding behaviour

## Testing
- ./gradlew test *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c84797ebcc832db41a0e1f1603d26c