### PR TITLE
Add unit tests for About screen view model and use cases

### DIFF
--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/about/GetCurrentYearUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/about/GetCurrentYearUseCaseTest.java
@@ -1,0 +1,25 @@
+package com.d4rk.androidtutorials.java.domain.about;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.d4rk.androidtutorials.java.data.repository.AboutRepository;
+
+import org.junit.Test;
+
+public class GetCurrentYearUseCaseTest {
+
+    @Test
+    public void invokeReturnsRepositoryCurrentYear() {
+        AboutRepository repository = mock(AboutRepository.class);
+        when(repository.getCurrentYear()).thenReturn("2030");
+        GetCurrentYearUseCase useCase = new GetCurrentYearUseCase(repository);
+
+        String result = useCase.invoke();
+
+        assertEquals("2030", result);
+        verify(repository).getCurrentYear();
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/about/GetVersionStringUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/about/GetVersionStringUseCaseTest.java
@@ -1,0 +1,25 @@
+package com.d4rk.androidtutorials.java.domain.about;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.d4rk.androidtutorials.java.data.repository.AboutRepository;
+
+import org.junit.Test;
+
+public class GetVersionStringUseCaseTest {
+
+    @Test
+    public void invokeReturnsRepositoryVersionString() {
+        AboutRepository repository = mock(AboutRepository.class);
+        when(repository.getVersionString()).thenReturn("v9.9.9");
+        GetVersionStringUseCase useCase = new GetVersionStringUseCase(repository);
+
+        String result = useCase.invoke();
+
+        assertEquals("v9.9.9", result);
+        verify(repository).getVersionString();
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/ui/screens/about/AboutViewModelTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/ui/screens/about/AboutViewModelTest.java
@@ -1,0 +1,40 @@
+package com.d4rk.androidtutorials.java.ui.screens.about;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.d4rk.androidtutorials.java.domain.about.GetCurrentYearUseCase;
+import com.d4rk.androidtutorials.java.domain.about.GetVersionStringUseCase;
+
+import org.junit.Test;
+
+public class AboutViewModelTest {
+
+    @Test
+    public void getVersionStringDelegatesToUseCase() {
+        GetVersionStringUseCase versionUseCase = mock(GetVersionStringUseCase.class);
+        GetCurrentYearUseCase currentYearUseCase = mock(GetCurrentYearUseCase.class);
+        when(versionUseCase.invoke()).thenReturn("v1.2.3 (45)");
+        AboutViewModel viewModel = new AboutViewModel(versionUseCase, currentYearUseCase);
+
+        String result = viewModel.getVersionString();
+
+        assertEquals("v1.2.3 (45)", result);
+        verify(versionUseCase).invoke();
+    }
+
+    @Test
+    public void getCurrentYearDelegatesToUseCase() {
+        GetVersionStringUseCase versionUseCase = mock(GetVersionStringUseCase.class);
+        GetCurrentYearUseCase currentYearUseCase = mock(GetCurrentYearUseCase.class);
+        when(currentYearUseCase.invoke()).thenReturn("2024");
+        AboutViewModel viewModel = new AboutViewModel(versionUseCase, currentYearUseCase);
+
+        String result = viewModel.getCurrentYear();
+
+        assertEquals("2024", result);
+        verify(currentYearUseCase).invoke();
+    }
+}


### PR DESCRIPTION
## Summary
- add AboutViewModel unit tests that mock the About use cases and verify their outputs
- add GetVersionStringUseCase and GetCurrentYearUseCase unit tests that assert repository delegation

## Testing
- ./gradlew test *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c847967f5c832d8cd819661dea3f39