### PR TITLE
Add domain use case unit tests

### DIFF
--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/about/GetCurrentYearUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/about/GetCurrentYearUseCaseTest.java
@@ -1,6 +1,8 @@
 package com.d4rk.androidtutorials.java.domain.about;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -20,6 +22,28 @@ public class GetCurrentYearUseCaseTest {
         String result = useCase.invoke();
 
         assertEquals("2030", result);
+        verify(repository).getCurrentYear();
+    }
+
+    @Test
+    public void invokeAllowsNullYear() {
+        AboutRepository repository = mock(AboutRepository.class);
+        when(repository.getCurrentYear()).thenReturn(null);
+        GetCurrentYearUseCase useCase = new GetCurrentYearUseCase(repository);
+
+        String result = useCase.invoke();
+
+        assertNull(result);
+        verify(repository).getCurrentYear();
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        AboutRepository repository = mock(AboutRepository.class);
+        when(repository.getCurrentYear()).thenThrow(new IllegalStateException("boom"));
+        GetCurrentYearUseCase useCase = new GetCurrentYearUseCase(repository);
+
+        assertThrows(IllegalStateException.class, useCase::invoke);
         verify(repository).getCurrentYear();
     }
 }

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/about/GetVersionStringUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/about/GetVersionStringUseCaseTest.java
@@ -1,6 +1,8 @@
 package com.d4rk.androidtutorials.java.domain.about;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -20,6 +22,28 @@ public class GetVersionStringUseCaseTest {
         String result = useCase.invoke();
 
         assertEquals("v9.9.9", result);
+        verify(repository).getVersionString();
+    }
+
+    @Test
+    public void invokeAllowsNullVersionString() {
+        AboutRepository repository = mock(AboutRepository.class);
+        when(repository.getVersionString()).thenReturn(null);
+        GetVersionStringUseCase useCase = new GetVersionStringUseCase(repository);
+
+        String result = useCase.invoke();
+
+        assertNull(result);
+        verify(repository).getVersionString();
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        AboutRepository repository = mock(AboutRepository.class);
+        when(repository.getVersionString()).thenThrow(new IllegalArgumentException("error"));
+        GetVersionStringUseCase useCase = new GetVersionStringUseCase(repository);
+
+        assertThrows(IllegalArgumentException.class, useCase::invoke);
         verify(repository).getVersionString();
     }
 }

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/android/GetLessonUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/android/GetLessonUseCaseTest.java
@@ -1,6 +1,8 @@
 package com.d4rk.androidtutorials.java.domain.android;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -21,6 +23,28 @@ public class GetLessonUseCaseTest {
         LessonRepository.Lesson result = useCase.invoke("intro");
 
         assertSame(lesson, result);
+        verify(repository).getLesson("intro");
+    }
+
+    @Test
+    public void invokeReturnsNullWhenRepositoryReturnsNull() {
+        LessonRepository repository = mock(LessonRepository.class);
+        when(repository.getLesson("advanced")).thenReturn(null);
+        GetLessonUseCase useCase = new GetLessonUseCase(repository);
+
+        LessonRepository.Lesson result = useCase.invoke("advanced");
+
+        assertNull(result);
+        verify(repository).getLesson("advanced");
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        LessonRepository repository = mock(LessonRepository.class);
+        when(repository.getLesson("intro")).thenThrow(new IllegalStateException("failure"));
+        GetLessonUseCase useCase = new GetLessonUseCase(repository);
+
+        assertThrows(IllegalStateException.class, () -> useCase.invoke("intro"));
         verify(repository).getLesson("intro");
     }
 }

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/help/LaunchReviewFlowUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/help/LaunchReviewFlowUseCaseTest.java
@@ -1,0 +1,63 @@
+package com.d4rk.androidtutorials.java.domain.help;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import android.app.Activity;
+
+import com.d4rk.androidtutorials.java.data.repository.HelpRepository;
+import com.google.android.play.core.review.ReviewInfo;
+
+import org.junit.Test;
+
+public class LaunchReviewFlowUseCaseTest {
+
+    @Test
+    public void invokeDelegatesToRepository() {
+        HelpRepository repository = mock(HelpRepository.class);
+        Activity activity = mock(Activity.class);
+        ReviewInfo info = mock(ReviewInfo.class);
+        LaunchReviewFlowUseCase useCase = new LaunchReviewFlowUseCase(repository);
+
+        useCase.invoke(activity, info);
+
+        verify(repository).launchReviewFlow(activity, info);
+    }
+
+    @Test
+    public void invokeAllowsNullActivity() {
+        HelpRepository repository = mock(HelpRepository.class);
+        ReviewInfo info = mock(ReviewInfo.class);
+        LaunchReviewFlowUseCase useCase = new LaunchReviewFlowUseCase(repository);
+
+        useCase.invoke(null, info);
+
+        verify(repository).launchReviewFlow(null, info);
+    }
+
+    @Test
+    public void invokeAllowsNullReviewInfo() {
+        HelpRepository repository = mock(HelpRepository.class);
+        Activity activity = mock(Activity.class);
+        LaunchReviewFlowUseCase useCase = new LaunchReviewFlowUseCase(repository);
+
+        useCase.invoke(activity, null);
+
+        verify(repository).launchReviewFlow(activity, null);
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        HelpRepository repository = mock(HelpRepository.class);
+        Activity activity = mock(Activity.class);
+        ReviewInfo info = mock(ReviewInfo.class);
+        LaunchReviewFlowUseCase useCase = new LaunchReviewFlowUseCase(repository);
+        doThrow(new IllegalArgumentException("failure"))
+                .when(repository).launchReviewFlow(activity, info);
+
+        assertThrows(IllegalArgumentException.class, () -> useCase.invoke(activity, info));
+        verify(repository).launchReviewFlow(activity, info);
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/help/RequestReviewFlowUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/help/RequestReviewFlowUseCaseTest.java
@@ -1,0 +1,46 @@
+package com.d4rk.androidtutorials.java.domain.help;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.d4rk.androidtutorials.java.data.repository.HelpRepository;
+
+import org.junit.Test;
+
+public class RequestReviewFlowUseCaseTest {
+
+    @Test
+    public void invokeDelegatesToRepository() {
+        HelpRepository repository = mock(HelpRepository.class);
+        HelpRepository.OnReviewInfoListener listener = mock(HelpRepository.OnReviewInfoListener.class);
+        RequestReviewFlowUseCase useCase = new RequestReviewFlowUseCase(repository);
+
+        useCase.invoke(listener);
+
+        verify(repository).requestReviewFlow(listener);
+    }
+
+    @Test
+    public void invokeAcceptsNullListener() {
+        HelpRepository repository = mock(HelpRepository.class);
+        RequestReviewFlowUseCase useCase = new RequestReviewFlowUseCase(repository);
+
+        useCase.invoke(null);
+
+        verify(repository).requestReviewFlow(null);
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        HelpRepository repository = mock(HelpRepository.class);
+        HelpRepository.OnReviewInfoListener listener = mock(HelpRepository.OnReviewInfoListener.class);
+        RequestReviewFlowUseCase useCase = new RequestReviewFlowUseCase(repository);
+        doThrow(new IllegalStateException("error"))
+                .when(repository).requestReviewFlow(listener);
+
+        assertThrows(IllegalStateException.class, () -> useCase.invoke(listener));
+        verify(repository).requestReviewFlow(listener);
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/home/GetAppPlayStoreUrlUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/home/GetAppPlayStoreUrlUseCaseTest.java
@@ -1,6 +1,8 @@
 package com.d4rk.androidtutorials.java.domain.home;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -20,6 +22,40 @@ public class GetAppPlayStoreUrlUseCaseTest {
         String result = useCase.invoke("pkg");
 
         assertEquals("url", result);
+        verify(repository).getAppPlayStoreUrl("pkg");
+    }
+
+    @Test
+    public void invokeDelegatesNullPackageName() {
+        HomeRepository repository = mock(HomeRepository.class);
+        when(repository.getAppPlayStoreUrl(null)).thenReturn("fallback");
+        GetAppPlayStoreUrlUseCase useCase = new GetAppPlayStoreUrlUseCase(repository);
+
+        String result = useCase.invoke(null);
+
+        assertEquals("fallback", result);
+        verify(repository).getAppPlayStoreUrl(null);
+    }
+
+    @Test
+    public void invokeReturnsNullWhenRepositoryReturnsNull() {
+        HomeRepository repository = mock(HomeRepository.class);
+        when(repository.getAppPlayStoreUrl("pkg")).thenReturn(null);
+        GetAppPlayStoreUrlUseCase useCase = new GetAppPlayStoreUrlUseCase(repository);
+
+        String result = useCase.invoke("pkg");
+
+        assertNull(result);
+        verify(repository).getAppPlayStoreUrl("pkg");
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        HomeRepository repository = mock(HomeRepository.class);
+        when(repository.getAppPlayStoreUrl("pkg")).thenThrow(new IllegalStateException("err"));
+        GetAppPlayStoreUrlUseCase useCase = new GetAppPlayStoreUrlUseCase(repository);
+
+        assertThrows(IllegalStateException.class, () -> useCase.invoke("pkg"));
         verify(repository).getAppPlayStoreUrl("pkg");
     }
 }

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/home/GetDailyTipUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/home/GetDailyTipUseCaseTest.java
@@ -1,6 +1,7 @@
 package com.d4rk.androidtutorials.java.domain.home;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -20,6 +21,28 @@ public class GetDailyTipUseCaseTest {
         String result = useCase.invoke();
 
         assertEquals("tip", result);
+        verify(repository).dailyTip();
+    }
+
+    @Test
+    public void invokeHandlesEmptyTip() {
+        HomeRepository repository = mock(HomeRepository.class);
+        when(repository.dailyTip()).thenReturn("");
+        GetDailyTipUseCase useCase = new GetDailyTipUseCase(repository);
+
+        String result = useCase.invoke();
+
+        assertEquals("", result);
+        verify(repository).dailyTip();
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        HomeRepository repository = mock(HomeRepository.class);
+        when(repository.dailyTip()).thenThrow(new IllegalArgumentException("bad"));
+        GetDailyTipUseCase useCase = new GetDailyTipUseCase(repository);
+
+        assertThrows(IllegalArgumentException.class, useCase::invoke);
         verify(repository).dailyTip();
     }
 }

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/home/GetPlayStoreUrlUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/home/GetPlayStoreUrlUseCaseTest.java
@@ -1,6 +1,8 @@
 package com.d4rk.androidtutorials.java.domain.home;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -20,6 +22,28 @@ public class GetPlayStoreUrlUseCaseTest {
         String result = useCase.invoke();
 
         assertEquals("url", result);
+        verify(repository).getPlayStoreUrl();
+    }
+
+    @Test
+    public void invokeReturnsNullWhenRepositoryReturnsNull() {
+        HomeRepository repository = mock(HomeRepository.class);
+        when(repository.getPlayStoreUrl()).thenReturn(null);
+        GetPlayStoreUrlUseCase useCase = new GetPlayStoreUrlUseCase(repository);
+
+        String result = useCase.invoke();
+
+        assertNull(result);
+        verify(repository).getPlayStoreUrl();
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        HomeRepository repository = mock(HomeRepository.class);
+        when(repository.getPlayStoreUrl()).thenThrow(new RuntimeException("fail"));
+        GetPlayStoreUrlUseCase useCase = new GetPlayStoreUrlUseCase(repository);
+
+        assertThrows(RuntimeException.class, useCase::invoke);
         verify(repository).getPlayStoreUrl();
     }
 }

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/home/GetPromotedAppsUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/home/GetPromotedAppsUseCaseTest.java
@@ -1,6 +1,8 @@
 package com.d4rk.androidtutorials.java.domain.home;
 
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -10,6 +12,7 @@ import com.d4rk.androidtutorials.java.data.repository.HomeRepository;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.util.Collections;
 import java.util.List;
 
 public class GetPromotedAppsUseCaseTest {
@@ -40,5 +43,52 @@ public class GetPromotedAppsUseCaseTest {
         captor.getValue().onResult(apps);
 
         verify(callback).onResult(apps);
+    }
+
+    @Test
+    public void invokePropagatesEmptyResults() {
+        HomeRepository repository = mock(HomeRepository.class);
+        GetPromotedAppsUseCase useCase = new GetPromotedAppsUseCase(repository);
+        GetPromotedAppsUseCase.Callback callback = mock(GetPromotedAppsUseCase.Callback.class);
+
+        useCase.invoke(callback);
+
+        ArgumentCaptor<HomeRepository.PromotedAppsCallback> captor =
+                ArgumentCaptor.forClass(HomeRepository.PromotedAppsCallback.class);
+        verify(repository).fetchPromotedApps(captor.capture());
+
+        List<PromotedApp> apps = Collections.emptyList();
+        captor.getValue().onResult(apps);
+
+        verify(callback).onResult(apps);
+    }
+
+    @Test
+    public void invokePropagatesNullResults() {
+        HomeRepository repository = mock(HomeRepository.class);
+        GetPromotedAppsUseCase useCase = new GetPromotedAppsUseCase(repository);
+        GetPromotedAppsUseCase.Callback callback = mock(GetPromotedAppsUseCase.Callback.class);
+
+        useCase.invoke(callback);
+
+        ArgumentCaptor<HomeRepository.PromotedAppsCallback> captor =
+                ArgumentCaptor.forClass(HomeRepository.PromotedAppsCallback.class);
+        verify(repository).fetchPromotedApps(captor.capture());
+
+        captor.getValue().onResult(null);
+
+        verify(callback).onResult(null);
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        HomeRepository repository = mock(HomeRepository.class);
+        GetPromotedAppsUseCase useCase = new GetPromotedAppsUseCase(repository);
+        GetPromotedAppsUseCase.Callback callback = mock(GetPromotedAppsUseCase.Callback.class);
+        doThrow(new IllegalStateException("failure"))
+                .when(repository).fetchPromotedApps(any());
+
+        assertThrows(IllegalStateException.class, () -> useCase.invoke(callback));
+        verify(repository).fetchPromotedApps(any());
     }
 }

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/main/ApplyLanguageSettingsUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/main/ApplyLanguageSettingsUseCaseTest.java
@@ -1,0 +1,34 @@
+package com.d4rk.androidtutorials.java.domain.main;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.d4rk.androidtutorials.java.data.repository.MainRepository;
+
+import org.junit.Test;
+
+public class ApplyLanguageSettingsUseCaseTest {
+
+    @Test
+    public void invokeCallsRepository() {
+        MainRepository repository = mock(MainRepository.class);
+        ApplyLanguageSettingsUseCase useCase = new ApplyLanguageSettingsUseCase(repository);
+
+        useCase.invoke();
+
+        verify(repository).applyLanguageSettings();
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        MainRepository repository = mock(MainRepository.class);
+        ApplyLanguageSettingsUseCase useCase = new ApplyLanguageSettingsUseCase(repository);
+        doThrow(new IllegalStateException("fail"))
+                .when(repository).applyLanguageSettings();
+
+        assertThrows(IllegalStateException.class, useCase::invoke);
+        verify(repository).applyLanguageSettings();
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/main/ApplyThemeSettingsUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/main/ApplyThemeSettingsUseCaseTest.java
@@ -1,0 +1,53 @@
+package com.d4rk.androidtutorials.java.domain.main;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.d4rk.androidtutorials.java.data.repository.MainRepository;
+
+import org.junit.Test;
+
+public class ApplyThemeSettingsUseCaseTest {
+
+    @Test
+    public void invokeReturnsRepositoryValue() {
+        MainRepository repository = mock(MainRepository.class);
+        String[] values = new String[]{"light", "dark"};
+        when(repository.applyThemeSettings(values)).thenReturn(true);
+        ApplyThemeSettingsUseCase useCase = new ApplyThemeSettingsUseCase(repository);
+
+        boolean changed = useCase.invoke(values);
+
+        assertTrue(changed);
+        verify(repository).applyThemeSettings(values);
+    }
+
+    @Test
+    public void invokeAllowsNullValues() {
+        MainRepository repository = mock(MainRepository.class);
+        when(repository.applyThemeSettings(null)).thenReturn(false);
+        ApplyThemeSettingsUseCase useCase = new ApplyThemeSettingsUseCase(repository);
+
+        boolean changed = useCase.invoke(null);
+
+        assertFalse(changed);
+        verify(repository).applyThemeSettings(null);
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        MainRepository repository = mock(MainRepository.class);
+        String[] values = new String[]{"system"};
+        when(repository.applyThemeSettings(values))
+                .thenThrow(new IllegalStateException("error"));
+        ApplyThemeSettingsUseCase useCase = new ApplyThemeSettingsUseCase(repository);
+
+        assertThrows(IllegalStateException.class,
+                () -> useCase.invoke(values));
+        verify(repository).applyThemeSettings(values);
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/main/GetAppUpdateManagerUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/main/GetAppUpdateManagerUseCaseTest.java
@@ -1,0 +1,51 @@
+package com.d4rk.androidtutorials.java.domain.main;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.d4rk.androidtutorials.java.data.repository.MainRepository;
+import com.google.android.play.core.appupdate.AppUpdateManager;
+
+import org.junit.Test;
+
+public class GetAppUpdateManagerUseCaseTest {
+
+    @Test
+    public void invokeReturnsManager() {
+        MainRepository repository = mock(MainRepository.class);
+        AppUpdateManager manager = mock(AppUpdateManager.class);
+        when(repository.getAppUpdateManager()).thenReturn(manager);
+        GetAppUpdateManagerUseCase useCase = new GetAppUpdateManagerUseCase(repository);
+
+        AppUpdateManager result = useCase.invoke();
+
+        assertSame(manager, result);
+        verify(repository).getAppUpdateManager();
+    }
+
+    @Test
+    public void invokeAllowsNullManager() {
+        MainRepository repository = mock(MainRepository.class);
+        when(repository.getAppUpdateManager()).thenReturn(null);
+        GetAppUpdateManagerUseCase useCase = new GetAppUpdateManagerUseCase(repository);
+
+        AppUpdateManager result = useCase.invoke();
+
+        assertNull(result);
+        verify(repository).getAppUpdateManager();
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        MainRepository repository = mock(MainRepository.class);
+        when(repository.getAppUpdateManager()).thenThrow(new IllegalStateException("error"));
+        GetAppUpdateManagerUseCase useCase = new GetAppUpdateManagerUseCase(repository);
+
+        assertThrows(IllegalStateException.class, useCase::invoke);
+        verify(repository).getAppUpdateManager();
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/main/GetBottomNavLabelVisibilityUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/main/GetBottomNavLabelVisibilityUseCaseTest.java
@@ -1,0 +1,53 @@
+package com.d4rk.androidtutorials.java.domain.main;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.d4rk.androidtutorials.java.data.repository.MainRepository;
+
+import org.junit.Test;
+
+public class GetBottomNavLabelVisibilityUseCaseTest {
+
+    @Test
+    public void invokeReturnsVisibilityValue() {
+        MainRepository repository = mock(MainRepository.class);
+        when(repository.getBottomNavLabelVisibility()).thenReturn("auto");
+        GetBottomNavLabelVisibilityUseCase useCase =
+                new GetBottomNavLabelVisibilityUseCase(repository);
+
+        String result = useCase.invoke();
+
+        assertEquals("auto", result);
+        verify(repository).getBottomNavLabelVisibility();
+    }
+
+    @Test
+    public void invokeReturnsNullWhenRepositoryReturnsNull() {
+        MainRepository repository = mock(MainRepository.class);
+        when(repository.getBottomNavLabelVisibility()).thenReturn(null);
+        GetBottomNavLabelVisibilityUseCase useCase =
+                new GetBottomNavLabelVisibilityUseCase(repository);
+
+        String result = useCase.invoke();
+
+        assertNull(result);
+        verify(repository).getBottomNavLabelVisibility();
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        MainRepository repository = mock(MainRepository.class);
+        when(repository.getBottomNavLabelVisibility())
+                .thenThrow(new IllegalStateException("fail"));
+        GetBottomNavLabelVisibilityUseCase useCase =
+                new GetBottomNavLabelVisibilityUseCase(repository);
+
+        assertThrows(IllegalStateException.class, useCase::invoke);
+        verify(repository).getBottomNavLabelVisibility();
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/main/GetDefaultTabPreferenceUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/main/GetDefaultTabPreferenceUseCaseTest.java
@@ -1,0 +1,50 @@
+package com.d4rk.androidtutorials.java.domain.main;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.d4rk.androidtutorials.java.data.repository.MainRepository;
+
+import org.junit.Test;
+
+public class GetDefaultTabPreferenceUseCaseTest {
+
+    @Test
+    public void invokeReturnsPreference() {
+        MainRepository repository = mock(MainRepository.class);
+        when(repository.getDefaultTabPreference()).thenReturn("home");
+        GetDefaultTabPreferenceUseCase useCase = new GetDefaultTabPreferenceUseCase(repository);
+
+        String result = useCase.invoke();
+
+        assertEquals("home", result);
+        verify(repository).getDefaultTabPreference();
+    }
+
+    @Test
+    public void invokeReturnsNullWhenRepositoryReturnsNull() {
+        MainRepository repository = mock(MainRepository.class);
+        when(repository.getDefaultTabPreference()).thenReturn(null);
+        GetDefaultTabPreferenceUseCase useCase = new GetDefaultTabPreferenceUseCase(repository);
+
+        String result = useCase.invoke();
+
+        assertNull(result);
+        verify(repository).getDefaultTabPreference();
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        MainRepository repository = mock(MainRepository.class);
+        when(repository.getDefaultTabPreference())
+                .thenThrow(new IllegalStateException("fail"));
+        GetDefaultTabPreferenceUseCase useCase = new GetDefaultTabPreferenceUseCase(repository);
+
+        assertThrows(IllegalStateException.class, useCase::invoke);
+        verify(repository).getDefaultTabPreference();
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/main/MarkStartupScreenShownUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/main/MarkStartupScreenShownUseCaseTest.java
@@ -1,0 +1,34 @@
+package com.d4rk.androidtutorials.java.domain.main;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.d4rk.androidtutorials.java.data.repository.MainRepository;
+
+import org.junit.Test;
+
+public class MarkStartupScreenShownUseCaseTest {
+
+    @Test
+    public void invokeCallsRepository() {
+        MainRepository repository = mock(MainRepository.class);
+        MarkStartupScreenShownUseCase useCase = new MarkStartupScreenShownUseCase(repository);
+
+        useCase.invoke();
+
+        verify(repository).markStartupScreenShown();
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        MainRepository repository = mock(MainRepository.class);
+        MarkStartupScreenShownUseCase useCase = new MarkStartupScreenShownUseCase(repository);
+        doThrow(new IllegalStateException("fail"))
+                .when(repository).markStartupScreenShown();
+
+        assertThrows(IllegalStateException.class, useCase::invoke);
+        verify(repository).markStartupScreenShown();
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/main/ShouldShowStartupScreenUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/main/ShouldShowStartupScreenUseCaseTest.java
@@ -1,0 +1,50 @@
+package com.d4rk.androidtutorials.java.domain.main;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.d4rk.androidtutorials.java.data.repository.MainRepository;
+
+import org.junit.Test;
+
+public class ShouldShowStartupScreenUseCaseTest {
+
+    @Test
+    public void invokeReturnsRepositoryValue() {
+        MainRepository repository = mock(MainRepository.class);
+        when(repository.shouldShowStartupScreen()).thenReturn(true);
+        ShouldShowStartupScreenUseCase useCase = new ShouldShowStartupScreenUseCase(repository);
+
+        boolean result = useCase.invoke();
+
+        assertTrue(result);
+        verify(repository).shouldShowStartupScreen();
+    }
+
+    @Test
+    public void invokeHandlesFalseValue() {
+        MainRepository repository = mock(MainRepository.class);
+        when(repository.shouldShowStartupScreen()).thenReturn(false);
+        ShouldShowStartupScreenUseCase useCase = new ShouldShowStartupScreenUseCase(repository);
+
+        boolean result = useCase.invoke();
+
+        assertFalse(result);
+        verify(repository).shouldShowStartupScreen();
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        MainRepository repository = mock(MainRepository.class);
+        when(repository.shouldShowStartupScreen())
+                .thenThrow(new IllegalStateException("error"));
+        ShouldShowStartupScreenUseCase useCase = new ShouldShowStartupScreenUseCase(repository);
+
+        assertThrows(IllegalStateException.class, useCase::invoke);
+        verify(repository).shouldShowStartupScreen();
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/settings/ApplyConsentUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/settings/ApplyConsentUseCaseTest.java
@@ -1,0 +1,34 @@
+package com.d4rk.androidtutorials.java.domain.settings;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.d4rk.androidtutorials.java.data.repository.SettingsRepository;
+
+import org.junit.Test;
+
+public class ApplyConsentUseCaseTest {
+
+    @Test
+    public void invokeCallsRepository() {
+        SettingsRepository repository = mock(SettingsRepository.class);
+        ApplyConsentUseCase useCase = new ApplyConsentUseCase(repository);
+
+        useCase.invoke();
+
+        verify(repository).applyConsent();
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        SettingsRepository repository = mock(SettingsRepository.class);
+        ApplyConsentUseCase useCase = new ApplyConsentUseCase(repository);
+        doThrow(new IllegalStateException("error"))
+                .when(repository).applyConsent();
+
+        assertThrows(IllegalStateException.class, useCase::invoke);
+        verify(repository).applyConsent();
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/settings/GetDarkModeUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/settings/GetDarkModeUseCaseTest.java
@@ -1,0 +1,49 @@
+package com.d4rk.androidtutorials.java.domain.settings;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.d4rk.androidtutorials.java.data.repository.SettingsRepository;
+
+import org.junit.Test;
+
+public class GetDarkModeUseCaseTest {
+
+    @Test
+    public void invokeReturnsDarkModeValue() {
+        SettingsRepository repository = mock(SettingsRepository.class);
+        when(repository.getDarkMode()).thenReturn("dark");
+        GetDarkModeUseCase useCase = new GetDarkModeUseCase(repository);
+
+        String result = useCase.invoke();
+
+        assertEquals("dark", result);
+        verify(repository).getDarkMode();
+    }
+
+    @Test
+    public void invokeReturnsNullWhenRepositoryReturnsNull() {
+        SettingsRepository repository = mock(SettingsRepository.class);
+        when(repository.getDarkMode()).thenReturn(null);
+        GetDarkModeUseCase useCase = new GetDarkModeUseCase(repository);
+
+        String result = useCase.invoke();
+
+        assertNull(result);
+        verify(repository).getDarkMode();
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        SettingsRepository repository = mock(SettingsRepository.class);
+        when(repository.getDarkMode()).thenThrow(new IllegalStateException("fail"));
+        GetDarkModeUseCase useCase = new GetDarkModeUseCase(repository);
+
+        assertThrows(IllegalStateException.class, useCase::invoke);
+        verify(repository).getDarkMode();
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/settings/OnPreferenceChangedUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/settings/OnPreferenceChangedUseCaseTest.java
@@ -1,0 +1,76 @@
+package com.d4rk.androidtutorials.java.domain.settings;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.d4rk.androidtutorials.java.data.repository.SettingsRepository;
+
+import org.junit.Test;
+
+public class OnPreferenceChangedUseCaseTest {
+
+    @Test
+    public void invokeDelegatesAndReturnsThemeChange() {
+        SettingsRepository repository = mock(SettingsRepository.class);
+        when(repository.applyTheme()).thenReturn(true);
+        OnPreferenceChangedUseCase useCase = new OnPreferenceChangedUseCase(repository);
+
+        boolean changed = useCase.invoke("dark_mode");
+
+        assertTrue(changed);
+        verify(repository).handlePreferenceChange("dark_mode");
+        verify(repository).applyTheme();
+    }
+
+    @Test
+    public void invokeReturnsFalseWhenThemeNotChanged() {
+        SettingsRepository repository = mock(SettingsRepository.class);
+        when(repository.applyTheme()).thenReturn(false);
+        OnPreferenceChangedUseCase useCase = new OnPreferenceChangedUseCase(repository);
+
+        boolean changed = useCase.invoke("notifications");
+
+        assertFalse(changed);
+        verify(repository).handlePreferenceChange("notifications");
+        verify(repository).applyTheme();
+    }
+
+    @Test
+    public void invokeSupportsNullKey() {
+        SettingsRepository repository = mock(SettingsRepository.class);
+        when(repository.applyTheme()).thenReturn(false);
+        OnPreferenceChangedUseCase useCase = new OnPreferenceChangedUseCase(repository);
+
+        useCase.invoke(null);
+
+        verify(repository).handlePreferenceChange(null);
+        verify(repository).applyTheme();
+    }
+
+    @Test
+    public void invokePropagatesExceptionFromHandle() {
+        SettingsRepository repository = mock(SettingsRepository.class);
+        doThrow(new IllegalStateException("error"))
+                .when(repository).handlePreferenceChange("key");
+        OnPreferenceChangedUseCase useCase = new OnPreferenceChangedUseCase(repository);
+
+        assertThrows(IllegalStateException.class, () -> useCase.invoke("key"));
+        verify(repository).handlePreferenceChange("key");
+    }
+
+    @Test
+    public void invokePropagatesExceptionFromApplyTheme() {
+        SettingsRepository repository = mock(SettingsRepository.class);
+        when(repository.applyTheme()).thenThrow(new IllegalStateException("apply"));
+        OnPreferenceChangedUseCase useCase = new OnPreferenceChangedUseCase(repository);
+
+        assertThrows(IllegalStateException.class, () -> useCase.invoke("key"));
+        verify(repository).handlePreferenceChange("key");
+        verify(repository).applyTheme();
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/settings/RegisterPreferenceChangeListenerUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/settings/RegisterPreferenceChangeListenerUseCaseTest.java
@@ -1,0 +1,53 @@
+package com.d4rk.androidtutorials.java.domain.settings;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import android.content.SharedPreferences;
+
+import com.d4rk.androidtutorials.java.data.repository.SettingsRepository;
+
+import org.junit.Test;
+
+public class RegisterPreferenceChangeListenerUseCaseTest {
+
+    @Test
+    public void invokeRegistersListener() {
+        SettingsRepository repository = mock(SettingsRepository.class);
+        SharedPreferences.OnSharedPreferenceChangeListener listener =
+                mock(SharedPreferences.OnSharedPreferenceChangeListener.class);
+        RegisterPreferenceChangeListenerUseCase useCase =
+                new RegisterPreferenceChangeListenerUseCase(repository);
+
+        useCase.invoke(listener);
+
+        verify(repository).registerPreferenceChangeListener(listener);
+    }
+
+    @Test
+    public void invokeAllowsNullListener() {
+        SettingsRepository repository = mock(SettingsRepository.class);
+        RegisterPreferenceChangeListenerUseCase useCase =
+                new RegisterPreferenceChangeListenerUseCase(repository);
+
+        useCase.invoke(null);
+
+        verify(repository).registerPreferenceChangeListener(null);
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        SettingsRepository repository = mock(SettingsRepository.class);
+        SharedPreferences.OnSharedPreferenceChangeListener listener =
+                mock(SharedPreferences.OnSharedPreferenceChangeListener.class);
+        RegisterPreferenceChangeListenerUseCase useCase =
+                new RegisterPreferenceChangeListenerUseCase(repository);
+        doThrow(new IllegalStateException("error"))
+                .when(repository).registerPreferenceChangeListener(listener);
+
+        assertThrows(IllegalStateException.class, () -> useCase.invoke(listener));
+        verify(repository).registerPreferenceChangeListener(listener);
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/settings/SetConsentAcceptedUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/settings/SetConsentAcceptedUseCaseTest.java
@@ -1,0 +1,44 @@
+package com.d4rk.androidtutorials.java.domain.settings;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.d4rk.androidtutorials.java.data.repository.SettingsRepository;
+
+import org.junit.Test;
+
+public class SetConsentAcceptedUseCaseTest {
+
+    @Test
+    public void invokeDelegatesTrueValue() {
+        SettingsRepository repository = mock(SettingsRepository.class);
+        SetConsentAcceptedUseCase useCase = new SetConsentAcceptedUseCase(repository);
+
+        useCase.invoke(true);
+
+        verify(repository).setConsentAccepted(true);
+    }
+
+    @Test
+    public void invokeDelegatesFalseValue() {
+        SettingsRepository repository = mock(SettingsRepository.class);
+        SetConsentAcceptedUseCase useCase = new SetConsentAcceptedUseCase(repository);
+
+        useCase.invoke(false);
+
+        verify(repository).setConsentAccepted(false);
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        SettingsRepository repository = mock(SettingsRepository.class);
+        SetConsentAcceptedUseCase useCase = new SetConsentAcceptedUseCase(repository);
+        doThrow(new IllegalStateException("fail"))
+                .when(repository).setConsentAccepted(true);
+
+        assertThrows(IllegalStateException.class, () -> useCase.invoke(true));
+        verify(repository).setConsentAccepted(true);
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/settings/UnregisterPreferenceChangeListenerUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/settings/UnregisterPreferenceChangeListenerUseCaseTest.java
@@ -1,0 +1,53 @@
+package com.d4rk.androidtutorials.java.domain.settings;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import android.content.SharedPreferences;
+
+import com.d4rk.androidtutorials.java.data.repository.SettingsRepository;
+
+import org.junit.Test;
+
+public class UnregisterPreferenceChangeListenerUseCaseTest {
+
+    @Test
+    public void invokeUnregistersListener() {
+        SettingsRepository repository = mock(SettingsRepository.class);
+        SharedPreferences.OnSharedPreferenceChangeListener listener =
+                mock(SharedPreferences.OnSharedPreferenceChangeListener.class);
+        UnregisterPreferenceChangeListenerUseCase useCase =
+                new UnregisterPreferenceChangeListenerUseCase(repository);
+
+        useCase.invoke(listener);
+
+        verify(repository).unregisterPreferenceChangeListener(listener);
+    }
+
+    @Test
+    public void invokeAllowsNullListener() {
+        SettingsRepository repository = mock(SettingsRepository.class);
+        UnregisterPreferenceChangeListenerUseCase useCase =
+                new UnregisterPreferenceChangeListenerUseCase(repository);
+
+        useCase.invoke(null);
+
+        verify(repository).unregisterPreferenceChangeListener(null);
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        SettingsRepository repository = mock(SettingsRepository.class);
+        SharedPreferences.OnSharedPreferenceChangeListener listener =
+                mock(SharedPreferences.OnSharedPreferenceChangeListener.class);
+        UnregisterPreferenceChangeListenerUseCase useCase =
+                new UnregisterPreferenceChangeListenerUseCase(repository);
+        doThrow(new IllegalStateException("error"))
+                .when(repository).unregisterPreferenceChangeListener(listener);
+
+        assertThrows(IllegalStateException.class, () -> useCase.invoke(listener));
+        verify(repository).unregisterPreferenceChangeListener(listener);
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/startup/LoadConsentFormUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/startup/LoadConsentFormUseCaseTest.java
@@ -1,0 +1,62 @@
+package com.d4rk.androidtutorials.java.domain.startup;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import android.app.Activity;
+
+import com.d4rk.androidtutorials.java.data.repository.StartupRepository;
+
+import org.junit.Test;
+
+public class LoadConsentFormUseCaseTest {
+
+    @Test
+    public void invokeDelegatesToRepository() {
+        StartupRepository repository = mock(StartupRepository.class);
+        Activity activity = mock(Activity.class);
+        StartupRepository.OnFormError onError = mock(StartupRepository.OnFormError.class);
+        LoadConsentFormUseCase useCase = new LoadConsentFormUseCase(repository);
+
+        useCase.invoke(activity, onError);
+
+        verify(repository).loadConsentForm(activity, onError);
+    }
+
+    @Test
+    public void invokeAllowsNullActivity() {
+        StartupRepository repository = mock(StartupRepository.class);
+        StartupRepository.OnFormError onError = mock(StartupRepository.OnFormError.class);
+        LoadConsentFormUseCase useCase = new LoadConsentFormUseCase(repository);
+
+        useCase.invoke(null, onError);
+
+        verify(repository).loadConsentForm(null, onError);
+    }
+
+    @Test
+    public void invokeAllowsNullErrorHandler() {
+        StartupRepository repository = mock(StartupRepository.class);
+        Activity activity = mock(Activity.class);
+        LoadConsentFormUseCase useCase = new LoadConsentFormUseCase(repository);
+
+        useCase.invoke(activity, null);
+
+        verify(repository).loadConsentForm(activity, null);
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        StartupRepository repository = mock(StartupRepository.class);
+        Activity activity = mock(Activity.class);
+        StartupRepository.OnFormError onError = mock(StartupRepository.OnFormError.class);
+        LoadConsentFormUseCase useCase = new LoadConsentFormUseCase(repository);
+        doThrow(new IllegalStateException("error"))
+                .when(repository).loadConsentForm(activity, onError);
+
+        assertThrows(IllegalStateException.class, () -> useCase.invoke(activity, onError));
+        verify(repository).loadConsentForm(activity, onError);
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/startup/RequestConsentInfoUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/startup/RequestConsentInfoUseCaseTest.java
@@ -1,0 +1,71 @@
+package com.d4rk.androidtutorials.java.domain.startup;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import android.app.Activity;
+
+import com.d4rk.androidtutorials.java.data.repository.StartupRepository;
+import com.google.android.ump.ConsentRequestParameters;
+
+import org.junit.Test;
+
+public class RequestConsentInfoUseCaseTest {
+
+    @Test
+    public void invokeDelegatesToRepository() {
+        StartupRepository repository = mock(StartupRepository.class);
+        Activity activity = mock(Activity.class);
+        ConsentRequestParameters params = mock(ConsentRequestParameters.class);
+        Runnable onSuccess = mock(Runnable.class);
+        StartupRepository.OnFormError onError = mock(StartupRepository.OnFormError.class);
+        RequestConsentInfoUseCase useCase = new RequestConsentInfoUseCase(repository);
+
+        useCase.invoke(activity, params, onSuccess, onError);
+
+        verify(repository).requestConsentInfoUpdate(activity, params, onSuccess, onError);
+    }
+
+    @Test
+    public void invokeSupportsNullParameters() {
+        StartupRepository repository = mock(StartupRepository.class);
+        Activity activity = mock(Activity.class);
+        Runnable onSuccess = mock(Runnable.class);
+        StartupRepository.OnFormError onError = mock(StartupRepository.OnFormError.class);
+        RequestConsentInfoUseCase useCase = new RequestConsentInfoUseCase(repository);
+
+        useCase.invoke(activity, null, onSuccess, onError);
+
+        verify(repository).requestConsentInfoUpdate(activity, null, onSuccess, onError);
+    }
+
+    @Test
+    public void invokeSupportsNullCallbacks() {
+        StartupRepository repository = mock(StartupRepository.class);
+        Activity activity = mock(Activity.class);
+        ConsentRequestParameters params = mock(ConsentRequestParameters.class);
+        RequestConsentInfoUseCase useCase = new RequestConsentInfoUseCase(repository);
+
+        useCase.invoke(activity, params, null, null);
+
+        verify(repository).requestConsentInfoUpdate(activity, params, null, null);
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        StartupRepository repository = mock(StartupRepository.class);
+        Activity activity = mock(Activity.class);
+        ConsentRequestParameters params = mock(ConsentRequestParameters.class);
+        Runnable onSuccess = mock(Runnable.class);
+        StartupRepository.OnFormError onError = mock(StartupRepository.OnFormError.class);
+        RequestConsentInfoUseCase useCase = new RequestConsentInfoUseCase(repository);
+        doThrow(new IllegalStateException("failure"))
+                .when(repository).requestConsentInfoUpdate(activity, params, onSuccess, onError);
+
+        assertThrows(IllegalStateException.class,
+                () -> useCase.invoke(activity, params, onSuccess, onError));
+        verify(repository).requestConsentInfoUpdate(activity, params, onSuccess, onError);
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/support/InitBillingClientUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/support/InitBillingClientUseCaseTest.java
@@ -1,0 +1,46 @@
+package com.d4rk.androidtutorials.java.domain.support;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.d4rk.androidtutorials.java.data.repository.SupportRepository;
+
+import org.junit.Test;
+
+public class InitBillingClientUseCaseTest {
+
+    @Test
+    public void invokeDelegatesToRepository() {
+        SupportRepository repository = mock(SupportRepository.class);
+        Runnable onConnected = mock(Runnable.class);
+        InitBillingClientUseCase useCase = new InitBillingClientUseCase(repository);
+
+        useCase.invoke(onConnected);
+
+        verify(repository).initBillingClient(onConnected);
+    }
+
+    @Test
+    public void invokeAllowsNullCallback() {
+        SupportRepository repository = mock(SupportRepository.class);
+        InitBillingClientUseCase useCase = new InitBillingClientUseCase(repository);
+
+        useCase.invoke(null);
+
+        verify(repository).initBillingClient(null);
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        SupportRepository repository = mock(SupportRepository.class);
+        Runnable onConnected = mock(Runnable.class);
+        InitBillingClientUseCase useCase = new InitBillingClientUseCase(repository);
+        doThrow(new IllegalStateException("failure"))
+                .when(repository).initBillingClient(onConnected);
+
+        assertThrows(IllegalStateException.class, () -> useCase.invoke(onConnected));
+        verify(repository).initBillingClient(onConnected);
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/support/InitMobileAdsUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/support/InitMobileAdsUseCaseTest.java
@@ -1,0 +1,51 @@
+package com.d4rk.androidtutorials.java.domain.support;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.d4rk.androidtutorials.java.data.repository.SupportRepository;
+import com.google.android.gms.ads.AdRequest;
+
+import org.junit.Test;
+
+public class InitMobileAdsUseCaseTest {
+
+    @Test
+    public void invokeReturnsAdRequest() {
+        SupportRepository repository = mock(SupportRepository.class);
+        AdRequest adRequest = mock(AdRequest.class);
+        when(repository.initMobileAds()).thenReturn(adRequest);
+        InitMobileAdsUseCase useCase = new InitMobileAdsUseCase(repository);
+
+        AdRequest result = useCase.invoke();
+
+        assertSame(adRequest, result);
+        verify(repository).initMobileAds();
+    }
+
+    @Test
+    public void invokeAllowsNullResult() {
+        SupportRepository repository = mock(SupportRepository.class);
+        when(repository.initMobileAds()).thenReturn(null);
+        InitMobileAdsUseCase useCase = new InitMobileAdsUseCase(repository);
+
+        AdRequest result = useCase.invoke();
+
+        assertNull(result);
+        verify(repository).initMobileAds();
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        SupportRepository repository = mock(SupportRepository.class);
+        when(repository.initMobileAds()).thenThrow(new IllegalStateException("boom"));
+        InitMobileAdsUseCase useCase = new InitMobileAdsUseCase(repository);
+
+        assertThrows(IllegalStateException.class, useCase::invoke);
+        verify(repository).initMobileAds();
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/support/InitiatePurchaseUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/support/InitiatePurchaseUseCaseTest.java
@@ -1,0 +1,63 @@
+package com.d4rk.androidtutorials.java.domain.support;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.d4rk.androidtutorials.java.data.repository.SupportRepository;
+
+import org.junit.Test;
+
+public class InitiatePurchaseUseCaseTest {
+
+    @Test
+    public void invokeReturnsLauncher() {
+        SupportRepository repository = mock(SupportRepository.class);
+        SupportRepository.BillingFlowLauncher launcher = mock(SupportRepository.BillingFlowLauncher.class);
+        when(repository.initiatePurchase("sku")).thenReturn(launcher);
+        InitiatePurchaseUseCase useCase = new InitiatePurchaseUseCase(repository);
+
+        SupportRepository.BillingFlowLauncher result = useCase.invoke("sku");
+
+        assertSame(launcher, result);
+        verify(repository).initiatePurchase("sku");
+    }
+
+    @Test
+    public void invokeAllowsNullProductId() {
+        SupportRepository repository = mock(SupportRepository.class);
+        SupportRepository.BillingFlowLauncher launcher = mock(SupportRepository.BillingFlowLauncher.class);
+        when(repository.initiatePurchase(null)).thenReturn(launcher);
+        InitiatePurchaseUseCase useCase = new InitiatePurchaseUseCase(repository);
+
+        SupportRepository.BillingFlowLauncher result = useCase.invoke(null);
+
+        assertSame(launcher, result);
+        verify(repository).initiatePurchase(null);
+    }
+
+    @Test
+    public void invokeAllowsNullLauncher() {
+        SupportRepository repository = mock(SupportRepository.class);
+        when(repository.initiatePurchase("sku")).thenReturn(null);
+        InitiatePurchaseUseCase useCase = new InitiatePurchaseUseCase(repository);
+
+        SupportRepository.BillingFlowLauncher result = useCase.invoke("sku");
+
+        assertNull(result);
+        verify(repository).initiatePurchase("sku");
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        SupportRepository repository = mock(SupportRepository.class);
+        when(repository.initiatePurchase("sku")).thenThrow(new IllegalStateException("error"));
+        InitiatePurchaseUseCase useCase = new InitiatePurchaseUseCase(repository);
+
+        assertThrows(IllegalStateException.class, () -> useCase.invoke("sku"));
+        verify(repository).initiatePurchase("sku");
+    }
+}

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/support/QueryProductDetailsUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/support/QueryProductDetailsUseCaseTest.java
@@ -1,0 +1,67 @@
+package com.d4rk.androidtutorials.java.domain.support;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.d4rk.androidtutorials.java.data.repository.SupportRepository;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+public class QueryProductDetailsUseCaseTest {
+
+    @Test
+    public void invokeDelegatesToRepository() {
+        SupportRepository repository = mock(SupportRepository.class);
+        List<String> productIds = List.of("one", "two");
+        SupportRepository.OnProductDetailsListener listener =
+                mock(SupportRepository.OnProductDetailsListener.class);
+        QueryProductDetailsUseCase useCase = new QueryProductDetailsUseCase(repository);
+
+        useCase.invoke(productIds, listener);
+
+        verify(repository).queryProductDetails(productIds, listener);
+    }
+
+    @Test
+    public void invokeSupportsEmptyProductIds() {
+        SupportRepository repository = mock(SupportRepository.class);
+        SupportRepository.OnProductDetailsListener listener =
+                mock(SupportRepository.OnProductDetailsListener.class);
+        QueryProductDetailsUseCase useCase = new QueryProductDetailsUseCase(repository);
+        List<String> ids = Collections.emptyList();
+
+        useCase.invoke(ids, listener);
+
+        verify(repository).queryProductDetails(ids, listener);
+    }
+
+    @Test
+    public void invokeSupportsNullArguments() {
+        SupportRepository repository = mock(SupportRepository.class);
+        QueryProductDetailsUseCase useCase = new QueryProductDetailsUseCase(repository);
+
+        useCase.invoke(null, null);
+
+        verify(repository).queryProductDetails(null, null);
+    }
+
+    @Test
+    public void invokePropagatesRepositoryException() {
+        SupportRepository repository = mock(SupportRepository.class);
+        List<String> productIds = List.of("id");
+        SupportRepository.OnProductDetailsListener listener =
+                mock(SupportRepository.OnProductDetailsListener.class);
+        QueryProductDetailsUseCase useCase = new QueryProductDetailsUseCase(repository);
+        doThrow(new IllegalStateException("failure"))
+                .when(repository).queryProductDetails(productIds, listener);
+
+        assertThrows(IllegalStateException.class,
+                () -> useCase.invoke(productIds, listener));
+        verify(repository).queryProductDetails(productIds, listener);
+    }
+}


### PR DESCRIPTION
## Summary
- expand existing domain tests to cover null results, empty responses, and propagated exceptions
- add unit tests for startup, help, support, main, and settings use cases to verify delegation and callback behaviour

## Testing
- ./gradlew test *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8916f5b0c832d82a459cabecd2262