### PR TITLE
Adjust Play Store URLs and add local data source tests

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/source/DefaultHomeLocalDataSource.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/source/DefaultHomeLocalDataSource.java
@@ -9,6 +9,8 @@ import com.d4rk.androidtutorials.java.R;
  */
 public class DefaultHomeLocalDataSource implements HomeLocalDataSource {
 
+    private static final String PLAY_STORE_BASE_URL = "https://play.google.com/store/apps/details?id=";
+
     private final Context context;
 
     public DefaultHomeLocalDataSource(Context context) {
@@ -17,12 +19,15 @@ public class DefaultHomeLocalDataSource implements HomeLocalDataSource {
 
     @Override
     public String getPlayStoreUrl() {
-        return "https://play.google.com/store/apps/details?id=com.d4rk.androidtutorials";
+        return PLAY_STORE_BASE_URL;
     }
 
     @Override
     public String getAppPlayStoreUrl(String packageName) {
-        return "https://play.google.com/store/apps/details?id=" + packageName;
+        if (packageName == null) {
+            return PLAY_STORE_BASE_URL;
+        }
+        return PLAY_STORE_BASE_URL + packageName;
     }
 
     @Override

--- a/app/src/test/java/com/d4rk/androidtutorials/java/data/source/local/DefaultHomeLocalDataSourceTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/data/source/local/DefaultHomeLocalDataSourceTest.java
@@ -1,4 +1,4 @@
-package com.d4rk.androidtutorials.java.data.source;
+package com.d4rk.androidtutorials.java.data.source.local;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -8,17 +8,45 @@ import android.content.Context;
 import android.content.res.Resources;
 
 import com.d4rk.androidtutorials.java.R;
+import com.d4rk.androidtutorials.java.data.source.DefaultHomeLocalDataSource;
 
 import org.junit.Test;
 
 public class DefaultHomeLocalDataSourceTest {
 
+    private static final String PLAY_STORE_BASE_URL = "https://play.google.com/store/apps/details?id=";
+
     @Test
-    public void playStoreUrlsFormattedCorrectly() {
+    public void getPlayStoreUrl_returnsBaseUrl() {
         DefaultHomeLocalDataSource dataSource =
                 new DefaultHomeLocalDataSource(mockContextWithTips(new String[]{"tip"}));
-        assertEquals("https://play.google.com/store/apps/details?id=com.d4rk.androidtutorials", dataSource.getPlayStoreUrl());
-        assertEquals("https://play.google.com/store/apps/details?id=pkg", dataSource.getAppPlayStoreUrl("pkg"));
+
+        assertEquals(PLAY_STORE_BASE_URL, dataSource.getPlayStoreUrl());
+    }
+
+    @Test
+    public void getAppPlayStoreUrl_appendsPackageName() {
+        DefaultHomeLocalDataSource dataSource =
+                new DefaultHomeLocalDataSource(mockContextWithTips(new String[]{"tip"}));
+
+        assertEquals(PLAY_STORE_BASE_URL + "com.example.app",
+                dataSource.getAppPlayStoreUrl("com.example.app"));
+    }
+
+    @Test
+    public void getAppPlayStoreUrl_allowsEmptyPackageName() {
+        DefaultHomeLocalDataSource dataSource =
+                new DefaultHomeLocalDataSource(mockContextWithTips(new String[]{"tip"}));
+
+        assertEquals(PLAY_STORE_BASE_URL, dataSource.getAppPlayStoreUrl(""));
+    }
+
+    @Test
+    public void getAppPlayStoreUrl_handlesNullPackageName() {
+        DefaultHomeLocalDataSource dataSource =
+                new DefaultHomeLocalDataSource(mockContextWithTips(new String[]{"tip"}));
+
+        assertEquals(PLAY_STORE_BASE_URL, dataSource.getAppPlayStoreUrl(null));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- return the Play Store base URL from DefaultHomeLocalDataSource and guard against null package names
- add unit tests under data/source/local covering base, empty, and null package names plus the daily tip behavior

## Testing
- ./gradlew test *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c976316340832da4917f85b05a48f7