### PR TITLE
Add tests for consent utils preference handling

### DIFF
--- a/app/src/test/java/com/d4rk/androidtutorials/java/utils/ConsentUtilsTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/utils/ConsentUtilsTest.java
@@ -25,6 +25,50 @@ import java.util.Map;
 public class ConsentUtilsTest {
 
     @Test
+    public void applyStoredConsent_readsPreferencesAndUpdatesFirebase() {
+        Context context = mock(Context.class);
+        SharedPreferences prefs = mock(SharedPreferences.class);
+        FirebaseAnalytics analytics = mock(FirebaseAnalytics.class);
+
+        when(context.getString(R.string.key_consent_analytics)).thenReturn("consent_analytics");
+        when(context.getString(R.string.key_consent_ad_storage)).thenReturn("consent_ad_storage");
+        when(context.getString(R.string.key_consent_ad_user_data)).thenReturn("consent_ad_user_data");
+        when(context.getString(R.string.key_consent_ad_personalization)).thenReturn("consent_ad_personalization");
+
+        when(prefs.getBoolean("consent_analytics", true)).thenReturn(false);
+        when(prefs.getBoolean("consent_ad_storage", true)).thenReturn(true);
+        when(prefs.getBoolean("consent_ad_user_data", true)).thenReturn(false);
+        when(prefs.getBoolean("consent_ad_personalization", true)).thenReturn(true);
+
+        try (MockedStatic<PreferenceManager> prefsStatic = Mockito.mockStatic(PreferenceManager.class);
+             MockedStatic<FirebaseAnalytics> firebaseStatic = Mockito.mockStatic(FirebaseAnalytics.class)) {
+            prefsStatic.when(() -> PreferenceManager.getDefaultSharedPreferences(context)).thenReturn(prefs);
+            firebaseStatic.when(() -> FirebaseAnalytics.getInstance(context)).thenReturn(analytics);
+
+            ConsentUtils.applyStoredConsent(context);
+
+            verify(prefs).getBoolean("consent_analytics", true);
+            verify(prefs).getBoolean("consent_ad_storage", true);
+            verify(prefs).getBoolean("consent_ad_user_data", true);
+            verify(prefs).getBoolean("consent_ad_personalization", true);
+
+            ArgumentCaptor<Map<FirebaseAnalytics.ConsentType, FirebaseAnalytics.ConsentStatus>> captor =
+                    ArgumentCaptor.forClass(Map.class);
+            verify(analytics).setConsent(captor.capture());
+            Map<FirebaseAnalytics.ConsentType, FirebaseAnalytics.ConsentStatus> consentMap = captor.getValue();
+
+            assertEquals(FirebaseAnalytics.ConsentStatus.DENIED,
+                    consentMap.get(FirebaseAnalytics.ConsentType.ANALYTICS_STORAGE));
+            assertEquals(FirebaseAnalytics.ConsentStatus.GRANTED,
+                    consentMap.get(FirebaseAnalytics.ConsentType.AD_STORAGE));
+            assertEquals(FirebaseAnalytics.ConsentStatus.DENIED,
+                    consentMap.get(FirebaseAnalytics.ConsentType.AD_USER_DATA));
+            assertEquals(FirebaseAnalytics.ConsentStatus.GRANTED,
+                    consentMap.get(FirebaseAnalytics.ConsentType.AD_PERSONALIZATION));
+        }
+    }
+
+    @Test
     public void updateFirebaseConsent_setsExpectedStatuses() {
         Context context = mock(Context.class);
         FirebaseAnalytics analytics = mock(FirebaseAnalytics.class);
@@ -73,6 +117,23 @@ public class ConsentUtilsTest {
 
             when(prefs.getBoolean("consent_ad_storage", true)).thenReturn(true);
             assertTrue(ConsentUtils.canShowAds(context));
+        }
+    }
+
+    @Test
+    public void canShowAds_returnsDefaultWhenPreferenceMissing() {
+        Context context = mock(Context.class);
+        SharedPreferences prefs = mock(SharedPreferences.class);
+        when(context.getString(R.string.key_consent_ad_storage)).thenReturn("consent_ad_storage");
+
+        try (MockedStatic<PreferenceManager> prefsStatic = Mockito.mockStatic(PreferenceManager.class)) {
+            prefsStatic.when(() -> PreferenceManager.getDefaultSharedPreferences(context)).thenReturn(prefs);
+
+            when(prefs.getBoolean("consent_ad_storage", true))
+                    .thenAnswer(invocation -> invocation.getArgument(1));
+
+            assertTrue(ConsentUtils.canShowAds(context));
+            verify(prefs).getBoolean("consent_ad_storage", true);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add coverage to ensure `applyStoredConsent` reads stored preferences and propagates them to Firebase consent
- verify `canShowAds` honours stored values and falls back to the default when no preference exists

## Testing
- ./gradlew test *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9765218d0832dbd5f376baa5d7e8b