### PR TITLE
Add test for AppUsageNotificationReceiver

### DIFF
--- a/app/src/test/java/com/d4rk/androidtutorials/java/notifications/receivers/AppUsageNotificationReceiverTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/notifications/receivers/AppUsageNotificationReceiverTest.java
@@ -1,0 +1,42 @@
+package com.d4rk.androidtutorials.java.notifications.receivers;
+
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.WorkManager;
+
+import com.d4rk.androidtutorials.java.notifications.workers.AppUsageNotificationWorker;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+public class AppUsageNotificationReceiverTest {
+
+    @Test
+    public void onReceive_enqueuesOneTimeWorkRequestForAppUsageNotificationWorker() {
+        Context context = mock(Context.class);
+        Intent intent = mock(Intent.class);
+        WorkManager workManager = mock(WorkManager.class);
+
+        try (MockedStatic<WorkManager> mockedWorkManager = mockStatic(WorkManager.class)) {
+            mockedWorkManager.when(() -> WorkManager.getInstance(context)).thenReturn(workManager);
+
+            AppUsageNotificationReceiver receiver = new AppUsageNotificationReceiver();
+            receiver.onReceive(context, intent);
+
+            ArgumentCaptor<OneTimeWorkRequest> requestCaptor = ArgumentCaptor.forClass(OneTimeWorkRequest.class);
+            verify(workManager).enqueue(requestCaptor.capture());
+
+            OneTimeWorkRequest request = requestCaptor.getValue();
+            assertEquals(AppUsageNotificationWorker.class.getName(),
+                    request.getWorkSpec().workerClassName);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a unit test covering AppUsageNotificationReceiver so onReceive enqueues an AppUsageNotificationWorker request

## Testing
- ./gradlew test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c97648c138832d81d16aa6dae545f3