### PR TITLE
Improve StartupWorker test verification

### DIFF
--- a/app/src/test/java/com/d4rk/androidtutorials/java/startup/StartupWorkerTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/startup/StartupWorkerTest.java
@@ -14,6 +14,7 @@ import org.mockito.MockedStatic;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 public class StartupWorkerTest {
@@ -31,8 +32,8 @@ public class StartupWorkerTest {
 
             ListenableWorker.Result result = worker.doWork();
 
-            mockedAdUtils.verify(() -> AdUtils.initialize(context));
-            mockedCookieManager.verify(CookieManager::getInstance);
+            mockedAdUtils.verify(() -> AdUtils.initialize(context), times(1));
+            mockedCookieManager.verify(CookieManager::getInstance, times(1));
             assertEquals(ListenableWorker.Result.success(), result);
         }
     }


### PR DESCRIPTION
## Summary
- ensure StartupWorkerTest verifies AdUtils.initialize is only invoked once
- confirm CookieManager.getInstance is mocked and verified once to avoid relying on the real WebView stack

## Testing
- ./gradlew test *(fails: Android SDK not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c97642acdc832dab32959c18d670e3