### PR TITLE
Prevent duplicate startup work scheduling

### DIFF
--- a/app/src/test/java/com/d4rk/androidtutorials/java/startup/StartupInitializerTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/startup/StartupInitializerTest.java
@@ -6,6 +6,8 @@ import androidx.work.ExistingWorkPolicy;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 
@@ -14,8 +16,19 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class StartupInitializerTest {
+
+    @Before
+    public void setUp() {
+        StartupInitializer.resetForTesting();
+    }
+
+    @After
+    public void tearDown() {
+        StartupInitializer.resetForTesting();
+    }
 
     @Test
     public void schedule_enqueuesWorkWithKeepPolicy() {
@@ -32,6 +45,26 @@ public class StartupInitializerTest {
                     eq(ExistingWorkPolicy.KEEP),
                     any(OneTimeWorkRequest.class)
             );
+        }
+    }
+
+    @Test
+    public void schedule_multipleCalls_enqueuesWorkOnlyOnce() {
+        Context context = mock(Context.class);
+        WorkManager workManager = mock(WorkManager.class);
+
+        try (MockedStatic<WorkManager> mockedWorkManager = mockStatic(WorkManager.class)) {
+            mockedWorkManager.when(() -> WorkManager.getInstance(context)).thenReturn(workManager);
+
+            StartupInitializer.schedule(context);
+            StartupInitializer.schedule(context);
+
+            verify(workManager).enqueueUniqueWork(
+                    eq("startup_init"),
+                    eq(ExistingWorkPolicy.KEEP),
+                    any(OneTimeWorkRequest.class)
+            );
+            verifyNoMoreInteractions(workManager);
         }
     }
 }


### PR DESCRIPTION
## Summary
- guard `StartupInitializer.schedule` so startup work only enqueues once per app launch
- add a visible-for-testing reset hook to clear scheduling state for unit tests
- expand startup tests to verify the unique work request and repeated scheduling behaviour

## Testing
- ./gradlew test *(fails: Android SDK not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c976429144832d99e05802da6b1aec