### PR TITLE
Handle invalid monospace font preferences

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/utils/FontManager.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/utils/FontManager.java
@@ -10,26 +10,56 @@ import com.d4rk.androidtutorials.java.R;
 
 public class FontManager {
 
+    private static final String DEFAULT_FONT_CODE = "6";
+
     public static Typeface getMonospaceFont(Context context, SharedPreferences prefs) {
         String key = context.getString(R.string.key_monospace_font);
         String font;
+        boolean resetPreference = false;
         try {
-            font = prefs.getString(key, "6");
+            font = prefs.getString(key, DEFAULT_FONT_CODE);
         } catch (ClassCastException e) {
-            prefs.edit().remove(key).apply();
-            font = "6";
+            font = DEFAULT_FONT_CODE;
+            resetPreference = true;
         }
         if (font == null) {
-            font = "6";
+            font = DEFAULT_FONT_CODE;
+            resetPreference = true;
         }
-        return switch (font) {
-            case "0" -> ResourcesCompat.getFont(context, R.font.font_audiowide);
-            case "1" -> ResourcesCompat.getFont(context, R.font.font_fira_code);
-            case "2" -> ResourcesCompat.getFont(context, R.font.font_jetbrains_mono);
-            case "3" -> ResourcesCompat.getFont(context, R.font.font_noto_sans_mono);
-            case "4" -> ResourcesCompat.getFont(context, R.font.font_poppins);
-            case "5" -> ResourcesCompat.getFont(context, R.font.font_roboto_mono);
-            default -> ResourcesCompat.getFont(context, R.font.font_google_sans_code);
-        };
+
+        Typeface typeface;
+        switch (font) {
+            case "0":
+                typeface = ResourcesCompat.getFont(context, R.font.font_audiowide);
+                break;
+            case "1":
+                typeface = ResourcesCompat.getFont(context, R.font.font_fira_code);
+                break;
+            case "2":
+                typeface = ResourcesCompat.getFont(context, R.font.font_jetbrains_mono);
+                break;
+            case "3":
+                typeface = ResourcesCompat.getFont(context, R.font.font_noto_sans_mono);
+                break;
+            case "4":
+                typeface = ResourcesCompat.getFont(context, R.font.font_poppins);
+                break;
+            case "5":
+                typeface = ResourcesCompat.getFont(context, R.font.font_roboto_mono);
+                break;
+            case DEFAULT_FONT_CODE:
+                typeface = ResourcesCompat.getFont(context, R.font.font_google_sans_code);
+                break;
+            default:
+                typeface = ResourcesCompat.getFont(context, R.font.font_google_sans_code);
+                resetPreference = true;
+                break;
+        }
+
+        if (resetPreference) {
+            prefs.edit().remove(key).apply();
+        }
+
+        return typeface;
     }
 }


### PR DESCRIPTION
## Summary
- ensure the monospace font helper treats null or malformed preference values as invalid and resets to the default
- expand the FontManager unit tests to cover valid, invalid, missing, and non-string preference scenarios

## Testing
- ./gradlew test *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9765aacd4832da141a072c7ae3b98