### PR TITLE
Ensure AdUtils initialization guards against null context

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ads/AdUtils.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ads/AdUtils.java
@@ -8,6 +8,8 @@ import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdView;
 import com.google.android.gms.ads.MobileAds;
 
+import java.util.Objects;
+
 public final class AdUtils {
     private static boolean initialized = false;
 
@@ -17,7 +19,9 @@ public final class AdUtils {
 
     public static synchronized void initialize(Context context) {
         if (!initialized) {
-            MobileAds.initialize(context.getApplicationContext());
+            Context nonNullContext = Objects.requireNonNull(context, "context == null");
+            Context appContext = nonNullContext.getApplicationContext();
+            MobileAds.initialize(appContext != null ? appContext : nonNullContext);
             initialized = true;
         }
     }


### PR DESCRIPTION
## Summary
- guard `AdUtils.initialize` against null contexts while preserving single initialization semantics
- expand the ads unit tests to mock `MobileAds`, verify the initialized flag, and assert null contexts throw `NullPointerException`

## Testing
- ./gradlew test *(fails: Android SDK not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c97643929c832da239f44757361341