### PR TITLE
Add callback propagation tests for domain use cases

### DIFF
--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/help/RequestReviewFlowUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/help/RequestReviewFlowUseCaseTest.java
@@ -1,11 +1,13 @@
 package com.d4rk.androidtutorials.java.domain.help;
 
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.d4rk.androidtutorials.java.data.repository.HelpRepository;
+import com.google.android.play.core.review.ReviewInfo;
 
 import org.junit.Test;
 
@@ -42,5 +44,41 @@ public class RequestReviewFlowUseCaseTest {
 
         assertThrows(IllegalStateException.class, () -> useCase.invoke(listener));
         verify(repository).requestReviewFlow(listener);
+    }
+
+    @Test
+    public void invokePropagatesSuccessCallback() {
+        HelpRepository repository = mock(HelpRepository.class);
+        HelpRepository.OnReviewInfoListener listener = mock(HelpRepository.OnReviewInfoListener.class);
+        RequestReviewFlowUseCase useCase = new RequestReviewFlowUseCase(repository);
+        ReviewInfo info = mock(ReviewInfo.class);
+        doAnswer(invocation -> {
+            HelpRepository.OnReviewInfoListener callback = invocation.getArgument(0);
+            callback.onSuccess(info);
+            return null;
+        }).when(repository).requestReviewFlow(listener);
+
+        useCase.invoke(listener);
+
+        verify(repository).requestReviewFlow(listener);
+        verify(listener).onSuccess(info);
+    }
+
+    @Test
+    public void invokePropagatesFailureCallback() {
+        HelpRepository repository = mock(HelpRepository.class);
+        HelpRepository.OnReviewInfoListener listener = mock(HelpRepository.OnReviewInfoListener.class);
+        RequestReviewFlowUseCase useCase = new RequestReviewFlowUseCase(repository);
+        Exception error = new Exception("fail");
+        doAnswer(invocation -> {
+            HelpRepository.OnReviewInfoListener callback = invocation.getArgument(0);
+            callback.onFailure(error);
+            return null;
+        }).when(repository).requestReviewFlow(listener);
+
+        useCase.invoke(listener);
+
+        verify(repository).requestReviewFlow(listener);
+        verify(listener).onFailure(error);
     }
 }

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/startup/LoadConsentFormUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/startup/LoadConsentFormUseCaseTest.java
@@ -1,6 +1,7 @@
 package com.d4rk.androidtutorials.java.domain.startup;
 
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -8,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import android.app.Activity;
 
 import com.d4rk.androidtutorials.java.data.repository.StartupRepository;
+import com.google.android.ump.FormError;
 
 import org.junit.Test;
 
@@ -45,6 +47,25 @@ public class LoadConsentFormUseCaseTest {
         useCase.invoke(activity, null);
 
         verify(repository).loadConsentForm(activity, null);
+    }
+
+    @Test
+    public void invokePropagatesFormErrorCallback() {
+        StartupRepository repository = mock(StartupRepository.class);
+        Activity activity = mock(Activity.class);
+        StartupRepository.OnFormError onError = mock(StartupRepository.OnFormError.class);
+        LoadConsentFormUseCase useCase = new LoadConsentFormUseCase(repository);
+        FormError formError = mock(FormError.class);
+        doAnswer(invocation -> {
+            StartupRepository.OnFormError callback = invocation.getArgument(1);
+            callback.onFormError(formError);
+            return null;
+        }).when(repository).loadConsentForm(activity, onError);
+
+        useCase.invoke(activity, onError);
+
+        verify(repository).loadConsentForm(activity, onError);
+        verify(onError).onFormError(formError);
     }
 
     @Test

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/startup/RequestConsentInfoUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/startup/RequestConsentInfoUseCaseTest.java
@@ -1,6 +1,7 @@
 package com.d4rk.androidtutorials.java.domain.startup;
 
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -9,6 +10,7 @@ import android.app.Activity;
 
 import com.d4rk.androidtutorials.java.data.repository.StartupRepository;
 import com.google.android.ump.ConsentRequestParameters;
+import com.google.android.ump.FormError;
 
 import org.junit.Test;
 
@@ -51,6 +53,47 @@ public class RequestConsentInfoUseCaseTest {
         useCase.invoke(activity, params, null, null);
 
         verify(repository).requestConsentInfoUpdate(activity, params, null, null);
+    }
+
+    @Test
+    public void invokePropagatesSuccessCallback() {
+        StartupRepository repository = mock(StartupRepository.class);
+        Activity activity = mock(Activity.class);
+        ConsentRequestParameters params = mock(ConsentRequestParameters.class);
+        Runnable onSuccess = mock(Runnable.class);
+        StartupRepository.OnFormError onError = mock(StartupRepository.OnFormError.class);
+        RequestConsentInfoUseCase useCase = new RequestConsentInfoUseCase(repository);
+        doAnswer(invocation -> {
+            Runnable callback = invocation.getArgument(2);
+            callback.run();
+            return null;
+        }).when(repository).requestConsentInfoUpdate(activity, params, onSuccess, onError);
+
+        useCase.invoke(activity, params, onSuccess, onError);
+
+        verify(repository).requestConsentInfoUpdate(activity, params, onSuccess, onError);
+        verify(onSuccess).run();
+    }
+
+    @Test
+    public void invokePropagatesFailureCallback() {
+        StartupRepository repository = mock(StartupRepository.class);
+        Activity activity = mock(Activity.class);
+        ConsentRequestParameters params = mock(ConsentRequestParameters.class);
+        Runnable onSuccess = mock(Runnable.class);
+        StartupRepository.OnFormError onError = mock(StartupRepository.OnFormError.class);
+        RequestConsentInfoUseCase useCase = new RequestConsentInfoUseCase(repository);
+        FormError error = mock(FormError.class);
+        doAnswer(invocation -> {
+            StartupRepository.OnFormError callback = invocation.getArgument(3);
+            callback.onFormError(error);
+            return null;
+        }).when(repository).requestConsentInfoUpdate(activity, params, onSuccess, onError);
+
+        useCase.invoke(activity, params, onSuccess, onError);
+
+        verify(repository).requestConsentInfoUpdate(activity, params, onSuccess, onError);
+        verify(onError).onFormError(error);
     }
 
     @Test

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/support/InitBillingClientUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/support/InitBillingClientUseCaseTest.java
@@ -1,6 +1,7 @@
 package com.d4rk.androidtutorials.java.domain.support;
 
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -20,6 +21,23 @@ public class InitBillingClientUseCaseTest {
         useCase.invoke(onConnected);
 
         verify(repository).initBillingClient(onConnected);
+    }
+
+    @Test
+    public void invokePropagatesConnectionCallback() {
+        SupportRepository repository = mock(SupportRepository.class);
+        Runnable onConnected = mock(Runnable.class);
+        InitBillingClientUseCase useCase = new InitBillingClientUseCase(repository);
+        doAnswer(invocation -> {
+            Runnable callback = invocation.getArgument(0);
+            callback.run();
+            return null;
+        }).when(repository).initBillingClient(onConnected);
+
+        useCase.invoke(onConnected);
+
+        verify(repository).initBillingClient(onConnected);
+        verify(onConnected).run();
     }
 
     @Test

--- a/app/src/test/java/com/d4rk/androidtutorials/java/domain/support/QueryProductDetailsUseCaseTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/domain/support/QueryProductDetailsUseCaseTest.java
@@ -1,10 +1,12 @@
 package com.d4rk.androidtutorials.java.domain.support;
 
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.android.billingclient.api.ProductDetails;
 import com.d4rk.androidtutorials.java.data.repository.SupportRepository;
 
 import org.junit.Test;
@@ -38,6 +40,27 @@ public class QueryProductDetailsUseCaseTest {
         useCase.invoke(ids, listener);
 
         verify(repository).queryProductDetails(ids, listener);
+    }
+
+    @Test
+    public void invokePropagatesListenerResults() {
+        SupportRepository repository = mock(SupportRepository.class);
+        List<String> productIds = List.of("product");
+        SupportRepository.OnProductDetailsListener listener =
+                mock(SupportRepository.OnProductDetailsListener.class);
+        QueryProductDetailsUseCase useCase = new QueryProductDetailsUseCase(repository);
+        ProductDetails detail = mock(ProductDetails.class);
+        List<ProductDetails> details = List.of(detail);
+        doAnswer(invocation -> {
+            SupportRepository.OnProductDetailsListener callback = invocation.getArgument(1);
+            callback.onProductDetailsRetrieved(details);
+            return null;
+        }).when(repository).queryProductDetails(productIds, listener);
+
+        useCase.invoke(productIds, listener);
+
+        verify(repository).queryProductDetails(productIds, listener);
+        verify(listener).onProductDetailsRetrieved(details);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- extend RequestReviewFlowUseCase tests to ensure review flow callbacks reach the caller
- verify support billing and product detail use cases forward repository callbacks and edge-case arguments
- assert startup consent form/update use cases propagate success and failure callbacks from the repository

## Testing
- ./gradlew test *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c976409fd0832db7f9af32f8ab9ce5