### PR TITLE
Inject clock for deterministic daily tips

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/data/source/DefaultHomeLocalDataSource.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/data/source/DefaultHomeLocalDataSource.java
@@ -4,15 +4,23 @@ import android.content.Context;
 
 import com.d4rk.androidtutorials.java.R;
 
+import java.time.Clock;
+
 /**
  * Default implementation that reads from Android resources.
  */
 public class DefaultHomeLocalDataSource implements HomeLocalDataSource {
 
     private final Context context;
+    private final Clock clock;
 
     public DefaultHomeLocalDataSource(Context context) {
+        this(context, Clock.systemUTC());
+    }
+
+    DefaultHomeLocalDataSource(Context context, Clock clock) {
         this.context = context.getApplicationContext();
+        this.clock = clock;
     }
 
     @Override
@@ -28,7 +36,11 @@ public class DefaultHomeLocalDataSource implements HomeLocalDataSource {
     @Override
     public String getDailyTip() {
         String[] tips = context.getResources().getStringArray(R.array.daily_tips);
-        long daysSinceEpoch = System.currentTimeMillis() / (24L * 60 * 60 * 1000);
+        if (tips.length == 0) {
+            throw new IllegalStateException("No daily tips available");
+        }
+        long millisPerDay = 24L * 60L * 60L * 1000L;
+        long daysSinceEpoch = clock.millis() / millisPerDay;
         int index = (int) (daysSinceEpoch % tips.length);
         return tips[index];
     }


### PR DESCRIPTION
## Summary
- inject a `Clock` into `DefaultHomeLocalDataSource` to make daily tip selection deterministic and guard against empty tip arrays
- expand `DefaultHomeLocalDataSourceTest` to cover day cycling, deterministic indexing, and empty data behavior

## Testing
- `./gradlew test` *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c976334d34832d8cb69fcaa47e22ae