### PR TITLE
Optimize layout containers for scroll performance

### DIFF
--- a/app/src/main/res/layout/activity_buttons.xml
+++ b/app/src/main/res/layout/activity_buttons.xml
@@ -14,7 +14,7 @@
 
         <androidx.appcompat.widget.LinearLayoutCompat
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:orientation="vertical">
 
             <com.google.android.material.textview.MaterialTextView

--- a/app/src/main/res/layout/activity_images.xml
+++ b/app/src/main/res/layout/activity_images.xml
@@ -14,7 +14,7 @@
 
         <androidx.appcompat.widget.LinearLayoutCompat
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:orientation="vertical">
 
             <com.google.android.material.textview.MaterialTextView

--- a/app/src/main/res/layout/activity_linear_layout.xml
+++ b/app/src/main/res/layout/activity_linear_layout.xml
@@ -14,7 +14,7 @@
 
         <androidx.appcompat.widget.LinearLayoutCompat
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:orientation="vertical">
 
             <com.google.android.material.textview.MaterialTextView
@@ -96,8 +96,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:layout_margin="24dp"
-                android:orientation="horizontal"
-                app:layout_constraintStart_toStartOf="parent">
+                android:orientation="horizontal">
 
                 <com.google.android.material.button.MaterialButton
                     style="@style/Widget.Material3.Button.ElevatedButton"

--- a/app/src/main/res/layout/activity_permissions.xml
+++ b/app/src/main/res/layout/activity_permissions.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
     <FrameLayout
         android:id="@+id/frame_layout_permissions"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+</FrameLayout>
+

--- a/app/src/main/res/layout/activity_permissions_tutorial.xml
+++ b/app/src/main/res/layout/activity_permissions_tutorial.xml
@@ -8,7 +8,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content">
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/text_view_permissions_beginning"

--- a/app/src/main/res/layout/activity_progress_bar.xml
+++ b/app/src/main/res/layout/activity_progress_bar.xml
@@ -14,7 +14,7 @@
 
         <androidx.appcompat.widget.LinearLayoutCompat
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:orientation="vertical">
 
             <com.google.android.material.textview.MaterialTextView
@@ -83,10 +83,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:layout_margin="24dp"
-                android:indeterminate="true"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                android:indeterminate="true" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/button_download"

--- a/app/src/main/res/layout/activity_startup.xml
+++ b/app/src/main/res/layout/activity_startup.xml
@@ -13,7 +13,7 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="wrap_content">
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/text_view_welcome"

--- a/app/src/main/res/layout/activity_switch.xml
+++ b/app/src/main/res/layout/activity_switch.xml
@@ -16,7 +16,7 @@
 
         <androidx.appcompat.widget.LinearLayoutCompat
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:orientation="vertical">
 
             <com.google.android.material.textview.MaterialTextView
@@ -66,7 +66,7 @@
                 <com.google.android.material.materialswitch.MaterialSwitch
                     android:id="@+id/material_switch_preference"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
+                    android:layout_height="wrap_content"
                     android:padding="24dp"
                     android:text="@string/switch_me"
                     android:tooltipText="@string/switch_me"

--- a/app/src/main/res/layout/dialog_bottom_sheet_menu.xml
+++ b/app/src/main/res/layout/dialog_bottom_sheet_menu.xml
@@ -31,7 +31,7 @@
 
         <androidx.appcompat.widget.LinearLayoutCompat
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:gravity="center_vertical"
             android:orientation="horizontal"
             android:padding="16dp">
@@ -95,7 +95,7 @@
 
         <androidx.appcompat.widget.LinearLayoutCompat
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:gravity="center_vertical"
             android:orientation="horizontal"
             android:padding="16dp">

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -12,7 +12,7 @@
 
         <androidx.appcompat.widget.LinearLayoutCompat
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
             android:gravity="center"
             android:orientation="vertical">


### PR DESCRIPTION
## Summary
- set ScrollView content containers to wrap_content heights across button, image, linear layout, switch, home, startup, and permissions tutorial screens to avoid redundant full-height measurement
- simplify permissions host activity to a FrameLayout and strip unused ConstraintLayout attributes, including redundant match_parent row heights in the bottom-sheet menu and circular indicator constraints

## Testing
- ./gradlew test *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc47f3fddc832d9266991efe85688d