### PR TITLE
Optimize layout wrappers and clean redundant attributes

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -24,7 +24,7 @@
         android:id="@+id/nav_rail"
         android:layout_width="wrap_content"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/ad_view"
+        app:layout_constraintBottom_toTopOf="@+id/ad_container"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/app_bar_layout"
         app:menu="@menu/bottom_nav_menu" />
@@ -35,20 +35,32 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:defaultNavHost="true"
-        app:layout_constraintBottom_toTopOf="@+id/ad_view"
+        app:layout_constraintBottom_toTopOf="@+id/ad_container"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/nav_rail"
         app:layout_constraintTop_toBottomOf="@id/app_bar_layout"
         app:navGraph="@navigation/mobile_navigation" />
 
-    <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
-        android:id="@+id/ad_view"
+    <FrameLayout
+        android:id="@+id/ad_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintBottom_toTopOf="@+id/nav_view"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:nativeAdLayout="@layout/ad_bottom_app_bar" />
+        app:layout_constraintStart_toStartOf="parent">
+
+        <View
+            android:id="@+id/ad_placeholder"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="?attr/colorSurfaceContainer" />
+
+        <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
+            android:id="@+id/ad_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:nativeAdLayout="@layout/ad_bottom_app_bar" />
+    </FrameLayout>
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/nav_view"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -24,7 +24,7 @@
         android:id="@+id/nav_rail"
         android:layout_width="wrap_content"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/ad_container"
+        app:layout_constraintBottom_toTopOf="@+id/ad_view"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/app_bar_layout"
         app:menu="@menu/bottom_nav_menu" />
@@ -35,30 +35,20 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:defaultNavHost="true"
-        app:layout_constraintBottom_toTopOf="@+id/ad_container"
+        app:layout_constraintBottom_toTopOf="@+id/ad_view"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/nav_rail"
         app:layout_constraintTop_toBottomOf="@id/app_bar_layout"
         app:navGraph="@navigation/mobile_navigation" />
 
-    <FrameLayout
-        android:id="@+id/ad_container"
+    <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
+        android:id="@+id/ad_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintBottom_toTopOf="@+id/nav_view">
-
-        <View
-            android:id="@+id/ad_placeholder"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="?attr/colorSurfaceContainer" />
-
-        <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
-            android:id="@+id/ad_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:nativeAdLayout="@layout/ad_bottom_app_bar" />
-    </FrameLayout>
+        app:layout_constraintBottom_toTopOf="@+id/nav_view"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:nativeAdLayout="@layout/ad_bottom_app_bar" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/nav_view"

--- a/app/src/main/res/layout/activity_shortcuts.xml
+++ b/app/src/main/res/layout/activity_shortcuts.xml
@@ -5,8 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
     <FrameLayout
         android:id="@+id/frame_layout_shortcuts"

--- a/app/src/main/res/layout/fragment_buttons_layout.xml
+++ b/app/src/main/res/layout/fragment_buttons_layout.xml
@@ -269,7 +269,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="24dp"
-        android:layout_marginTop="0dp"
         android:layout_marginEnd="24dp"
         android:layout_marginBottom="24dp"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_clock_layout.xml
+++ b/app/src/main/res/layout/fragment_clock_layout.xml
@@ -77,7 +77,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="24dp"
-        android:layout_marginTop="0dp"
         android:layout_marginEnd="24dp"
         android:layout_marginBottom="24dp"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_code.xml
+++ b/app/src/main/res/layout/fragment_code.xml
@@ -33,7 +33,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="24dp"
-        android:layout_marginTop="0dp"
         android:layout_marginEnd="24dp"
         android:layout_marginBottom="24dp"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -188,7 +188,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="16dp"
-                android:layout_marginBottom="0dp"
                 app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.CardViewTopRounded">
 
                 <androidx.appcompat.widget.LinearLayoutCompat

--- a/app/src/main/res/layout/fragment_layout.xml
+++ b/app/src/main/res/layout/fragment_layout.xml
@@ -33,7 +33,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="24dp"
-        android:layout_marginTop="0dp"
         android:layout_marginEnd="24dp"
         android:layout_marginBottom="24dp"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_linear_layout_layout.xml
+++ b/app/src/main/res/layout/fragment_linear_layout_layout.xml
@@ -59,7 +59,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="24dp"
-        android:layout_marginTop="0dp"
         android:layout_marginEnd="24dp"
         android:layout_marginBottom="24dp"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_no_code.xml
+++ b/app/src/main/res/layout/fragment_no_code.xml
@@ -30,7 +30,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="24dp"
-        android:layout_marginTop="0dp"
         android:layout_marginEnd="24dp"
         android:layout_marginBottom="24dp"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_same_code.xml
+++ b/app/src/main/res/layout/fragment_same_code.xml
@@ -55,7 +55,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="24dp"
-        android:layout_marginTop="0dp"
         android:layout_marginEnd="24dp"
         android:layout_marginBottom="24dp"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/item_onboarding_option.xml
+++ b/app/src/main/res/layout/item_onboarding_option.xml
@@ -57,7 +57,6 @@
             android:id="@+id/radio_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="0dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"/>


### PR DESCRIPTION
## Summary
- flatten the main activity ad container by removing the unused FrameLayout placeholder and constraining the banner view directly
- drop redundant zero-valued margins and other no-op attributes across lesson layouts to trim XML bloat

## Testing
- ./gradlew test *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc50f00d44832d9332b80079088004