### PR TITLE
Add external icon for browser-based lessons

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/AndroidStudioFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/AndroidStudioFragment.java
@@ -176,6 +176,7 @@ public class AndroidStudioFragment extends Fragment {
                         String data = parser.getAttributeValue("http://schemas.android.com/apk/res/android", "data");
                         if (data != null) intent.setData(Uri.parse(data));
                         currentLesson.intent = intent;
+                        currentLesson.opensInBrowser = isBrowserIntent(intent);
                     }
                 } else if (event == XmlPullParser.END_TAG) {
                     String name = parser.getName();
@@ -189,6 +190,22 @@ public class AndroidStudioFragment extends Fragment {
         } catch (XmlPullParserException | IOException ignored) {
         }
         return items;
+    }
+
+    private boolean isBrowserIntent(Intent intent) {
+        if (intent.getComponent() != null) {
+            return false;
+        }
+        Uri data = intent.getData();
+        if (data == null) {
+            return false;
+        }
+        String scheme = data.getScheme();
+        if (scheme == null) {
+            return false;
+        }
+        return Intent.ACTION_VIEW.equals(intent.getAction())
+                && ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme));
     }
 
     private void populateAdapter(List<Object> source, boolean showAds) {
@@ -262,6 +279,7 @@ public class AndroidStudioFragment extends Fragment {
         String summary;
         int iconRes;
         Intent intent;
+        boolean opensInBrowser;
     }
 
     private static class Category {
@@ -329,7 +347,8 @@ public class AndroidStudioFragment extends Fragment {
                     if (oldItem instanceof Lesson oldLesson && newItem instanceof Lesson newLesson) {
                         return Objects.equals(oldLesson.title, newLesson.title)
                                 && Objects.equals(oldLesson.summary, newLesson.summary)
-                                && oldLesson.iconRes == newLesson.iconRes;
+                                && oldLesson.iconRes == newLesson.iconRes
+                                && oldLesson.opensInBrowser == newLesson.opensInBrowser;
                     }
                     if (oldItem instanceof Category oldCat && newItem instanceof Category newCat) {
                         return Objects.equals(oldCat.title, newCat.title)
@@ -415,6 +434,7 @@ public class AndroidStudioFragment extends Fragment {
             final AppCompatImageView icon;
             final MaterialTextView title;
             final MaterialTextView summary;
+            final AppCompatImageView externalIcon;
 
             LessonHolder(@NonNull ItemAndroidStudioLessonBinding binding) {
                 super(binding.getRoot());
@@ -422,6 +442,7 @@ public class AndroidStudioFragment extends Fragment {
                 icon = binding.lessonIcon;
                 title = binding.lessonTitle;
                 summary = binding.lessonSummary;
+                externalIcon = binding.lessonExternalIcon;
             }
 
             void bind(Lesson lesson, boolean first, boolean last) {
@@ -438,6 +459,7 @@ public class AndroidStudioFragment extends Fragment {
                 } else {
                     summary.setVisibility(View.GONE);
                 }
+                externalIcon.setVisibility(lesson.opensInBrowser ? View.VISIBLE : View.GONE);
                 itemView.setOnClickListener(v -> {
                     if (lesson.intent != null) {
                         v.getContext().startActivity(lesson.intent);

--- a/app/src/main/res/drawable-anydpi/ic_open_in_new.xml
+++ b/app/src/main/res/drawable-anydpi/ic_open_in_new.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/colorOnSurfaceVariant"
+        android:pathData="M14,3v2h3.59l-4.83,4.83 1.41,1.41L19,6.41V10h2V3h-7zM5,5h6V3H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2v-6h-2v6H5V5z" />
+</vector>

--- a/app/src/main/res/layout/item_android_studio_lesson.xml
+++ b/app/src/main/res/layout/item_android_studio_lesson.xml
@@ -44,5 +44,15 @@
                 android:layout_height="wrap_content"
                 android:textAppearance="@style/TextAppearance.Material3.BodySmall" />
         </androidx.appcompat.widget.LinearLayoutCompat>
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/lesson_external_icon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginStart="12dp"
+            android:contentDescription="@null"
+            android:importantForAccessibility="no"
+            app:srcCompat="@drawable/ic_open_in_new"
+            android:visibility="gone" />
     </androidx.appcompat.widget.LinearLayoutCompat>
 </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
## Summary
- detect lessons that launch external browser URLs when parsing the Android Studio lesson catalog
- surface a new external-link indicator in the lesson row layout and wire it up in the adapter
- add a Material vector asset for the external link icon

## Testing
- ./gradlew test *(fails: Android SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0efbae98832d96c7e028f6089151