### PR TITLE
Align onboarding default tab with persisted preference

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/onboarding/OnboardingViewModel.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/onboarding/OnboardingViewModel.java
@@ -62,6 +62,11 @@ public class OnboardingViewModel extends ViewModel {
         prefs.edit().putString(context.getString(R.string.key_default_tab), value).apply();
     }
 
+    public String getDefaultTab() {
+        String[] values = context.getResources().getStringArray(R.array.preference_default_tab_values);
+        return prefs.getString(context.getString(R.string.key_default_tab), values[0]);
+    }
+
     public void setBottomNavLabels(String value) {
         prefs.edit().putString(context.getString(R.string.key_bottom_navigation_bar_labels), value).apply();
     }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/onboarding/StartPageFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/onboarding/StartPageFragment.java
@@ -48,7 +48,17 @@ public class StartPageFragment extends Fragment {
         binding.optionSecond.radioButton.setId(View.generateViewId());
         binding.optionThird.radioButton.setId(View.generateViewId());
 
-        selectOption(0);
+        String[] values = getResources().getStringArray(R.array.preference_default_tab_values);
+        String savedValue = viewModel.getDefaultTab();
+        int selectedIndex = 0;
+        for (int i = 0; i < values.length; i++) {
+            if (values[i].equals(savedValue)) {
+                selectedIndex = i;
+                break;
+            }
+        }
+
+        selectOption(selectedIndex);
 
         binding.cardFirst.setOnClickListener(v -> selectOption(0));
         binding.cardSecond.setOnClickListener(v -> selectOption(1));
@@ -63,17 +73,23 @@ public class StartPageFragment extends Fragment {
         binding.optionFirst.radioButton.setChecked(index == 0);
         binding.optionSecond.radioButton.setChecked(index == 1);
         binding.optionThird.radioButton.setChecked(index == 2);
+
+        if (viewModel != null) {
+            String[] values = getResources().getStringArray(R.array.preference_default_tab_values);
+            if (index >= 0 && index < values.length) {
+                viewModel.setDefaultTab(values[index]);
+            }
+        }
     }
 
     public void saveSelection() {
-        String[] values = getResources().getStringArray(R.array.preference_default_tab_values);
-        String value = values[0];
         if (binding.optionSecond.radioButton.isChecked()) {
-            value = values[1];
+            selectOption(1);
         } else if (binding.optionThird.radioButton.isChecked()) {
-            value = values[2];
+            selectOption(2);
+        } else {
+            selectOption(0);
         }
-        viewModel.setDefaultTab(value);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- add an OnboardingViewModel helper to retrieve the stored default tab preference
- initialize StartPageFragment from the saved tab value and persist changes as soon as the user makes a selection

## Testing
- ./gradlew test *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd14988458832d91ceb9d11fc35a4a