### PR TITLE
Remove manual personalized ads gating

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/AndroidStudioFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/AndroidStudioFragment.java
@@ -32,7 +32,6 @@ import com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView;
 import com.d4rk.androidtutorials.java.databinding.FragmentAndroidStudioBinding;
 import com.d4rk.androidtutorials.java.databinding.ItemAndroidStudioCategoryBinding;
 import com.d4rk.androidtutorials.java.databinding.ItemAndroidStudioLessonBinding;
-import com.d4rk.androidtutorials.java.utils.ConsentUtils;
 import com.google.android.gms.ads.AdListener;
 import com.google.android.gms.ads.LoadAdError;
 import com.google.android.material.card.MaterialCardView;
@@ -57,7 +56,6 @@ public class AndroidStudioFragment extends Fragment {
     private static boolean mobileAdsInitialized = false;
     private final List<Object> allItems = new ArrayList<>();
     private LessonsAdapter adapter;
-    private boolean showAds;
     private FragmentAndroidStudioBinding binding;
 
     @Nullable
@@ -71,20 +69,15 @@ public class AndroidStudioFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        showAds = ConsentUtils.canShowPersonalizedAds(requireContext());
-        if (showAds) {
-            ensureMobileAdsInitialized();
-        }
+        ensureMobileAdsInitialized();
         RecyclerView list = binding.lessonsList;
         list.setLayoutManager(new LinearLayoutManager(requireContext()));
         adapter = new LessonsAdapter();
         list.setAdapter(adapter);
-        if (showAds) {
-            list.addItemDecoration(new LessonAdSpacingDecoration(requireContext()));
-        }
+        list.addItemDecoration(new LessonAdSpacingDecoration(requireContext()));
         allItems.clear();
         allItems.addAll(loadItems());
-        populateAdapter(allItems, showAds);
+        populateAdapter(allItems);
 
         MenuHost menuHost = requireActivity();
         menuHost.addMenuProvider(new MenuProvider() {
@@ -208,7 +201,7 @@ public class AndroidStudioFragment extends Fragment {
                 && ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme));
     }
 
-    private void populateAdapter(List<Object> source, boolean showAds) {
+    private void populateAdapter(List<Object> source) {
         List<Object> items = new ArrayList<>();
         List<Integer> eligible = new ArrayList<>();
         int lessonCount = 0;
@@ -224,7 +217,7 @@ public class AndroidStudioFragment extends Fragment {
                 firstInCategory = false;
             }
         }
-        int adCount = showAds ? lessonCount / 3 : 0;
+        int adCount = lessonCount / 3;
         Collections.shuffle(eligible, new Random());
         if (adCount > eligible.size()) {
             adCount = eligible.size();
@@ -248,7 +241,7 @@ public class AndroidStudioFragment extends Fragment {
     private void filterLessons(String query) {
         String lower = query == null ? "" : query.toLowerCase();
         if (lower.isEmpty()) {
-            populateAdapter(allItems, showAds);
+            populateAdapter(allItems);
             return;
         }
         List<Object> filtered = new ArrayList<>();
@@ -268,7 +261,7 @@ public class AndroidStudioFragment extends Fragment {
                 }
             }
         }
-        populateAdapter(filtered, showAds);
+        populateAdapter(filtered);
     }
 
     private static class AdItem {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/utils/ConsentUtils.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/utils/ConsentUtils.java
@@ -39,9 +39,4 @@ public class ConsentUtils {
                 adPersonalization ? FirebaseAnalytics.ConsentStatus.GRANTED : FirebaseAnalytics.ConsentStatus.DENIED);
         FirebaseAnalytics.getInstance(context).setConsent(consentMap);
     }
-
-    public static boolean canShowPersonalizedAds(Context context) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        return prefs.getBoolean(context.getString(R.string.key_consent_ad_storage), true);
-    }
 }

--- a/app/src/test/java/com/d4rk/androidtutorials/java/utils/ConsentUtilsTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/utils/ConsentUtilsTest.java
@@ -1,8 +1,6 @@
 package com.d4rk.androidtutorials.java.utils;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -103,37 +101,4 @@ public class ConsentUtilsTest {
         }
     }
 
-    @Test
-    public void canShowAds_readsStoredPreference() {
-        Context context = mock(Context.class);
-        SharedPreferences prefs = mock(SharedPreferences.class);
-        when(context.getString(R.string.key_consent_ad_storage)).thenReturn("consent_ad_storage");
-
-        try (MockedStatic<PreferenceManager> prefsStatic = Mockito.mockStatic(PreferenceManager.class)) {
-            prefsStatic.when(() -> PreferenceManager.getDefaultSharedPreferences(context)).thenReturn(prefs);
-
-            when(prefs.getBoolean("consent_ad_storage", true)).thenReturn(false);
-            assertFalse(ConsentUtils.canShowPersonalizedAds(context));
-
-            when(prefs.getBoolean("consent_ad_storage", true)).thenReturn(true);
-            assertTrue(ConsentUtils.canShowPersonalizedAds(context));
-        }
-    }
-
-    @Test
-    public void canShowAds_returnsDefaultWhenPreferenceMissing() {
-        Context context = mock(Context.class);
-        SharedPreferences prefs = mock(SharedPreferences.class);
-        when(context.getString(R.string.key_consent_ad_storage)).thenReturn("consent_ad_storage");
-
-        try (MockedStatic<PreferenceManager> prefsStatic = Mockito.mockStatic(PreferenceManager.class)) {
-            prefsStatic.when(() -> PreferenceManager.getDefaultSharedPreferences(context)).thenReturn(prefs);
-
-            when(prefs.getBoolean("consent_ad_storage", true))
-                    .thenAnswer(invocation -> invocation.getArgument(1));
-
-            assertTrue(ConsentUtils.canShowPersonalizedAds(context));
-            verify(prefs).getBoolean("consent_ad_storage", true);
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- stop using the removed `canShowPersonalizedAds` helper and always set up ads in `AndroidStudioFragment`
- delete the redundant helper from `ConsentUtils`
- drop the associated unit tests that exercised the helper

## Testing
- ./gradlew test *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd165be240832d8b169e40b53faf51