### PR TITLE
Ensure overflow menus display item icons

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/navigation/BaseActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/navigation/BaseActivity.java
@@ -1,11 +1,14 @@
 package com.d4rk.androidtutorials.java.ui.components.navigation;
 
+import android.annotation.SuppressLint;
 import android.os.Bundle;
+import android.view.Menu;
 import android.view.View;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.view.menu.MenuBuilder;
 
 import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
@@ -23,6 +26,16 @@ public abstract class BaseActivity extends AppCompatActivity {
         if (actionBar != null) {
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
+    }
+
+    @SuppressLint("RestrictedApi")
+    @Override
+    public boolean onMenuOpened(int featureId, Menu menu) {
+        if (menu instanceof MenuBuilder) {
+            MenuBuilder menuBuilder = (MenuBuilder) menu;
+            menuBuilder.setOptionalIconsVisible(true);
+        }
+        return super.onMenuOpened(featureId, menu);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- ensure all BaseActivity-derived screens force overflow menus to show optional item icons

## Testing
- `./gradlew test` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1997250c832db57e4092eb7f6a54