### PR TITLE
Resolve FIXME warnings across navigation and consent handling

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/navigation/BaseActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/navigation/BaseActivity.java
@@ -31,8 +31,7 @@ public abstract class BaseActivity extends AppCompatActivity {
     @SuppressLint("RestrictedApi")
     @Override
     public boolean onMenuOpened(int featureId, Menu menu) {
-        if (menu instanceof MenuBuilder) {
-            MenuBuilder menuBuilder = (MenuBuilder) menu; // FIXME: Variable 'menuBuilder' can be replaced with pattern variable
+        if (menu instanceof MenuBuilder menuBuilder) {
             menuBuilder.setOptionalIconsVisible(true);
         }
         return super.onMenuOpened(featureId, menu);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainActivity.java
@@ -71,10 +71,17 @@ public class MainActivity extends AppCompatActivity {
         @Override
         public void onResume(@NonNull LifecycleOwner owner) {
             ConsentUtils.applyStoredConsent(MainActivity.this);
-            if (mBinding != null && mBinding.adView != null) {
-                mBinding.adPlaceholder.setVisibility(View.GONE); // FIXME: Method invocation 'setVisibility' may produce 'NullPointerException'
-                mBinding.adView.setVisibility(View.VISIBLE);
-                AdUtils.loadBanner(mBinding.adView);
+            ActivityMainBinding binding = mBinding;
+            if (binding != null) {
+                View adView = binding.adView;
+                if (adView != null) {
+                    View adPlaceholder = binding.adPlaceholder;
+                    if (adPlaceholder != null) {
+                        adPlaceholder.setVisibility(View.GONE);
+                    }
+                    adView.setVisibility(View.VISIBLE);
+                    AdUtils.loadBanner(adView);
+                }
             }
         }
     };
@@ -201,19 +208,29 @@ public class MainActivity extends AppCompatActivity {
             }
             NavigationBarView navBarView = (NavigationBarView) binding.navView;
             if (useRail) {
-                binding.navRail.setVisibility(View.VISIBLE); // FIXME: Method invocation 'setVisibility' may produce 'NullPointerException'
+                View navRail = binding.navRail;
+                if (navRail != null) {
+                    navRail.setVisibility(View.VISIBLE);
+                }
                 navBarView.setVisibility(View.GONE);
                 EdgeToEdgeDelegate.apply(this, binding.container);
             } else {
-                binding.navRail.setVisibility(View.GONE); // FIXME: Method invocation 'setVisibility' may produce 'NullPointerException'
+                View navRail = binding.navRail;
+                if (navRail != null) {
+                    navRail.setVisibility(View.GONE);
+                }
                 navBarView.setVisibility(View.VISIBLE);
                 EdgeToEdgeDelegate.applyBottomBar(this, binding.container, navBarView);
 
                 navBarView.setLabelVisibilityMode(uiState.bottomNavVisibility());
-                if (binding.adView != null) {
-                    binding.adPlaceholder.setVisibility(View.GONE); // FIXME: Method invocation 'setVisibility' may produce 'NullPointerException'
-                    binding.adView.setVisibility(View.VISIBLE);
-                    AdUtils.loadBanner(binding.adView);
+                View adView = binding.adView;
+                if (adView != null) {
+                    View adPlaceholder = binding.adPlaceholder;
+                    if (adPlaceholder != null) {
+                        adPlaceholder.setVisibility(View.GONE);
+                    }
+                    adView.setVisibility(View.VISIBLE);
+                    AdUtils.loadBanner(adView);
                 }
             }
 
@@ -304,8 +321,9 @@ public class MainActivity extends AppCompatActivity {
         });
 
         mainViewModel.getLoadingState().observe(this, isLoading -> {
-            if (mBinding != null) {
-                mBinding.progressBar.setVisibility(Boolean.TRUE.equals(isLoading) ? View.VISIBLE : View.GONE); // FIXME: Method invocation 'setVisibility' may produce 'NullPointerException'
+            ActivityMainBinding binding = mBinding;
+            if (binding != null) {
+                binding.progressBar.setVisibility(Boolean.TRUE.equals(isLoading) ? View.VISIBLE : View.GONE);
             }
         });
     }
@@ -316,15 +334,9 @@ public class MainActivity extends AppCompatActivity {
             return;
         }
         NavGraph graph = navController.getGraph();
-        if (graph != null) {// FIXME: Condition 'graph != null' is always 'true'
-            graph.setStartDestination(preferredDestination);
-        }
+        graph.setStartDestination(preferredDestination);
         androidx.navigation.NavDestination currentDestination = navController.getCurrentDestination();
         if (currentDestination != null && currentDestination.getId() == preferredDestination) {
-            lastPreferredStartDestination = preferredDestination;
-            return;
-        }
-        if (graph == null) { // FIXME: Condition 'graph == null' is always 'false'
             lastPreferredStartDestination = preferredDestination;
             return;
         }

--- a/app/src/test/java/com/d4rk/androidtutorials/java/utils/ConsentUtilsTest.java
+++ b/app/src/test/java/com/d4rk/androidtutorials/java/utils/ConsentUtilsTest.java
@@ -1,6 +1,5 @@
 package com.d4rk.androidtutorials.java.utils;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -14,10 +13,10 @@ import com.d4rk.androidtutorials.java.R;
 import com.google.firebase.analytics.FirebaseAnalytics;
 
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.util.EnumMap;
 import java.util.Map;
 
 public class ConsentUtilsTest {
@@ -50,19 +49,18 @@ public class ConsentUtilsTest {
             verify(prefs).getBoolean("consent_ad_user_data", true);
             verify(prefs).getBoolean("consent_ad_personalization", true);
 
-            ArgumentCaptor<Map<FirebaseAnalytics.ConsentType, FirebaseAnalytics.ConsentStatus>> captor =
-                    ArgumentCaptor.forClass(Map.class); // FIXME: Unchecked assignment: 'org.mockito.ArgumentCaptor' to 'org.mockito.ArgumentCaptor<java.util.Map<com.google.firebase.analytics.FirebaseAnalytics.ConsentType,com.google.firebase.analytics.FirebaseAnalytics.ConsentStatus>>' && Unchecked method 'forClass(Class<S>)' invocation
-            verify(analytics).setConsent(captor.capture());
-            Map<FirebaseAnalytics.ConsentType, FirebaseAnalytics.ConsentStatus> consentMap = captor.getValue();
+            Map<FirebaseAnalytics.ConsentType, FirebaseAnalytics.ConsentStatus> expectedConsent =
+                    new EnumMap<>(FirebaseAnalytics.ConsentType.class);
+            expectedConsent.put(FirebaseAnalytics.ConsentType.ANALYTICS_STORAGE,
+                    FirebaseAnalytics.ConsentStatus.DENIED);
+            expectedConsent.put(FirebaseAnalytics.ConsentType.AD_STORAGE,
+                    FirebaseAnalytics.ConsentStatus.GRANTED);
+            expectedConsent.put(FirebaseAnalytics.ConsentType.AD_USER_DATA,
+                    FirebaseAnalytics.ConsentStatus.DENIED);
+            expectedConsent.put(FirebaseAnalytics.ConsentType.AD_PERSONALIZATION,
+                    FirebaseAnalytics.ConsentStatus.GRANTED);
 
-            assertEquals(FirebaseAnalytics.ConsentStatus.DENIED,
-                    consentMap.get(FirebaseAnalytics.ConsentType.ANALYTICS_STORAGE));
-            assertEquals(FirebaseAnalytics.ConsentStatus.GRANTED,
-                    consentMap.get(FirebaseAnalytics.ConsentType.AD_STORAGE));
-            assertEquals(FirebaseAnalytics.ConsentStatus.DENIED,
-                    consentMap.get(FirebaseAnalytics.ConsentType.AD_USER_DATA));
-            assertEquals(FirebaseAnalytics.ConsentStatus.GRANTED,
-                    consentMap.get(FirebaseAnalytics.ConsentType.AD_PERSONALIZATION));
+            verify(analytics).setConsent(expectedConsent);
         }
     }
 
@@ -85,19 +83,18 @@ public class ConsentUtilsTest {
                     adUserDataConsent,
                     adPersonalizationConsent);
 
-            ArgumentCaptor<Map<FirebaseAnalytics.ConsentType, FirebaseAnalytics.ConsentStatus>> captor =
-                    ArgumentCaptor.forClass(Map.class); // FIXME: Unchecked assignment: 'org.mockito.ArgumentCaptor' to 'org.mockito.ArgumentCaptor<java.util.Map<com.google.firebase.analytics.FirebaseAnalytics.ConsentType,com.google.firebase.analytics.FirebaseAnalytics.ConsentStatus>>' && Unchecked method 'forClass(Class<S>)' invocation
-            verify(analytics).setConsent(captor.capture());
-            Map<FirebaseAnalytics.ConsentType, FirebaseAnalytics.ConsentStatus> result = captor.getValue();
+            Map<FirebaseAnalytics.ConsentType, FirebaseAnalytics.ConsentStatus> expectedConsent =
+                    new EnumMap<>(FirebaseAnalytics.ConsentType.class);
+            expectedConsent.put(FirebaseAnalytics.ConsentType.ANALYTICS_STORAGE,
+                    FirebaseAnalytics.ConsentStatus.GRANTED);
+            expectedConsent.put(FirebaseAnalytics.ConsentType.AD_STORAGE,
+                    FirebaseAnalytics.ConsentStatus.DENIED);
+            expectedConsent.put(FirebaseAnalytics.ConsentType.AD_USER_DATA,
+                    FirebaseAnalytics.ConsentStatus.GRANTED);
+            expectedConsent.put(FirebaseAnalytics.ConsentType.AD_PERSONALIZATION,
+                    FirebaseAnalytics.ConsentStatus.DENIED);
 
-            assertEquals(FirebaseAnalytics.ConsentStatus.GRANTED,
-                    result.get(FirebaseAnalytics.ConsentType.ANALYTICS_STORAGE));
-            assertEquals(FirebaseAnalytics.ConsentStatus.DENIED,
-                    result.get(FirebaseAnalytics.ConsentType.AD_STORAGE));
-            assertEquals(FirebaseAnalytics.ConsentStatus.GRANTED,
-                    result.get(FirebaseAnalytics.ConsentType.AD_USER_DATA));
-            assertEquals(FirebaseAnalytics.ConsentStatus.DENIED,
-                    result.get(FirebaseAnalytics.ConsentType.AD_PERSONALIZATION));
+            verify(analytics).setConsent(expectedConsent);
         }
     }
 


### PR DESCRIPTION
## Summary
- replace the Mockito `ArgumentCaptor` usage in `ConsentUtilsTest` with explicit consent map verification to eliminate unchecked warnings
- use pattern matching for `instanceof` in `BaseActivity` when enabling optional menu icons
- guard `MainActivity` view interactions against null bindings and drop redundant null checks when updating the navigation graph

## Testing
- `./gradlew test` *(fails: Android SDK is not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1e29e0a8832da8c917dafe62d0f2