### PR TITLE
Enable edge-to-edge handling across activities

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/onboarding/OnboardingActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/onboarding/OnboardingActivity.java
@@ -17,6 +17,7 @@ import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivityOnboardingBinding;
 import com.d4rk.androidtutorials.java.ui.screens.main.MainActivity;
 import com.d4rk.androidtutorials.java.ui.screens.startup.StartupViewModel;
+import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
 import com.google.android.ump.ConsentInformation;
@@ -38,6 +39,8 @@ public class OnboardingActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         binding = ActivityOnboardingBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        EdgeToEdgeDelegate.apply(this, binding.getRoot());
 
         viewModel = new ViewModelProvider(this).get(OnboardingViewModel.class);
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/startup/StartupActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/startup/StartupActivity.java
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModelProvider;
 import com.d4rk.androidtutorials.java.databinding.ActivityStartupBinding;
 import com.d4rk.androidtutorials.java.startup.StartupInitializer;
 import com.d4rk.androidtutorials.java.ui.screens.onboarding.OnboardingActivity;
+import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 import com.google.android.ump.ConsentRequestParameters;
 
 import dagger.hilt.android.AndroidEntryPoint;
@@ -25,6 +26,8 @@ public class StartupActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         ActivityStartupBinding binding = ActivityStartupBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        EdgeToEdgeDelegate.apply(this, binding.getRoot());
 
         StartupInitializer.schedule(this);
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/utils/EdgeToEdgeDelegate.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/utils/EdgeToEdgeDelegate.java
@@ -2,11 +2,16 @@ package com.d4rk.androidtutorials.java.utils;
 
 import android.app.Activity;
 import android.view.View;
+import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
+import androidx.core.view.ViewGroupCompat;
 import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
+
+import com.d4rk.androidtutorials.java.R;
 
 public final class EdgeToEdgeDelegate {
 
@@ -14,27 +19,118 @@ public final class EdgeToEdgeDelegate {
         // Utility class
     }
 
-    public static void apply(Activity activity, View container) {
-        WindowCompat.setDecorFitsSystemWindows(activity.getWindow(), false);
-
-        ViewCompat.setOnApplyWindowInsetsListener(container, (v, insets) -> {
-            Insets bars = insets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
-            v.setPadding(bars.left, bars.top, bars.right, bars.bottom);
-            return WindowInsetsCompat.CONSUMED;
-        });
+    public static void apply(Activity activity, View view) {
+        enableEdgeToEdge(activity);
+        applyInsetsAsPadding(
+                view,
+                WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout(),
+                true,
+                true,
+                true,
+                true
+        );
     }
 
     public static void applyBottomBar(Activity activity, View container, View bottomNavigationView) {
-        WindowCompat.setDecorFitsSystemWindows(activity.getWindow(), false);
+        enableEdgeToEdge(activity);
+        applyInsetsAsPadding(
+                container,
+                WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout(),
+                true,
+                true,
+                true,
+                false
+        );
+        applyInsetsAsPadding(
+                bottomNavigationView,
+                WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout(),
+                true,
+                false,
+                true,
+                true
+        );
+    }
 
-        ViewCompat.setOnApplyWindowInsetsListener(container, (v, insets) -> {
-            Insets bars = insets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
-            v.setPadding(bars.left, bars.top, bars.right, 0);
+    private static void enableEdgeToEdge(Activity activity) {
+        if (activity == null) {
+            return;
+        }
+        WindowCompat.enableEdgeToEdge(activity.getWindow());
+    }
 
-            if (bottomNavigationView != null) {
-                bottomNavigationView.setPadding(0, 0, 0, bars.bottom);
-            }
-            return WindowInsetsCompat.CONSUMED;
+    private static void applyInsetsAsPadding(View view, int insetTypes,
+                                             boolean applyStart, boolean applyTop,
+                                             boolean applyEnd, boolean applyBottom) {
+        if (view == null) {
+            return;
+        }
+
+        if (view instanceof ViewGroup viewGroup) {
+            ViewGroupCompat.installCompatInsetsDispatch(viewGroup);
+        }
+
+        InsetsPadding basePadding = (InsetsPadding) view.getTag(R.id.tag_edge_to_edge_padding);
+        if (basePadding == null) {
+            basePadding = new InsetsPadding(
+                    view.getPaddingStart(),
+                    view.getPaddingTop(),
+                    view.getPaddingEnd(),
+                    view.getPaddingBottom()
+            );
+            view.setTag(R.id.tag_edge_to_edge_padding, basePadding);
+        }
+
+        InsetsPadding padding = basePadding;
+        ViewCompat.setOnApplyWindowInsetsListener(view, (v, windowInsets) -> {
+            Insets insets = windowInsets.getInsets(insetTypes);
+            int start = applyStart ? insets.left : 0;
+            int top = applyTop ? insets.top : 0;
+            int end = applyEnd ? insets.right : 0;
+            int bottom = applyBottom ? insets.bottom : 0;
+
+            ViewCompat.setPaddingRelative(
+                    v,
+                    padding.start + start,
+                    padding.top + top,
+                    padding.end + end,
+                    padding.bottom + bottom
+            );
+            return windowInsets;
         });
+
+        requestApplyInsetsWhenAttached(view);
+    }
+
+    private static void requestApplyInsetsWhenAttached(@NonNull View view) {
+        if (ViewCompat.isAttachedToWindow(view)) {
+            ViewCompat.requestApplyInsets(view);
+        } else {
+            view.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
+                @Override
+                public void onViewAttachedToWindow(View v) {
+                    v.removeOnAttachStateChangeListener(this);
+                    ViewCompat.requestApplyInsets(v);
+                }
+
+                @Override
+                public void onViewDetachedFromWindow(View v) {
+                    // No-op
+                }
+            });
+        }
+    }
+
+    private static final class InsetsPadding {
+        final int start;
+        final int top;
+        final int end;
+        final int bottom;
+
+        InsetsPadding(int start, int top, int end, int bottom) {
+            this.start = start;
+            this.top = top;
+            this.end = end;
+            this.bottom = bottom;
+        }
     }
 }

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -2,8 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fitsSystemWindows="true">
+    android:layout_height="match_parent">
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonSkip"

--- a/app/src/main/res/layout/activity_startup.xml
+++ b/app/src/main/res/layout/activity_startup.xml
@@ -2,8 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fitsSystemWindows="true">
+    android:layout_height="match_parent">
 
     <me.zhanghai.android.fastscroll.FastScrollScrollView
         android:id="@+id/scroll_view"

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="tag_edge_to_edge_padding" type="id" />
+</resources>


### PR DESCRIPTION
## Summary
- refactor `EdgeToEdgeDelegate` to use `WindowCompat.enableEdgeToEdge` and preserve original padding when reacting to window insets
- apply the shared edge-to-edge handling to the onboarding and startup flows and drop `fitsSystemWindows`
- add a dedicated view tag id for tracking base padding

## Testing
- ./gradlew test *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd2c1e85f8832d94507efc7baaa254