### PR TITLE
Add AdChoices icon to about banner ad

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ads/managers/NativeAdLoader.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ads/managers/NativeAdLoader.java
@@ -17,6 +17,7 @@ import com.google.android.gms.ads.AdListener;
 import com.google.android.gms.ads.AdLoader;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.LoadAdError;
+import com.google.android.gms.ads.nativead.AdChoicesView;
 import com.google.android.gms.ads.nativead.MediaView;
 import com.google.android.gms.ads.nativead.NativeAd;
 import com.google.android.gms.ads.nativead.NativeAdView;
@@ -84,6 +85,7 @@ public class NativeAdLoader {
         Button callToActionView = adView.findViewById(R.id.ad_call_to_action);
         ImageView iconView = adView.findViewById(R.id.ad_app_icon);
         TextView attributionView = adView.findViewById(R.id.ad_attribution);
+        AdChoicesView adChoicesView = adView.findViewById(R.id.ad_choices);
 
         if (mediaView != null) {
             adView.setMediaView(mediaView);
@@ -95,6 +97,9 @@ public class NativeAdLoader {
             adView.setIconView(iconView);
         }
         adView.setAdvertiserView(attributionView);
+        if (adChoicesView != null) {
+            adView.setAdChoicesView(adChoicesView);
+        }
 
         if (headlineView != null) {
             headlineView.setText(nativeAd.getHeadline());

--- a/app/src/main/res/layout/ad_about.xml
+++ b/app/src/main/res/layout/ad_about.xml
@@ -43,6 +43,15 @@
                         android:layout_height="match_parent" />
                 </com.google.android.material.card.MaterialCardView>
 
+                <com.google.android.gms.ads.nativead.AdChoicesView
+                    android:id="@+id/ad_choices"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:layout_marginEnd="4dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/ad_headline"
                     android:layout_width="0dp"


### PR DESCRIPTION
## Summary
- add an AdChoices view to the about screen native ad layout so the "Why this ad" icon can render
- wire the ad loader to register the AdChoices view with the native ad view

## Testing
- ./gradlew test *(fails: Android SDK is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdcd01038c832dacc5f2ed5793bce1