### PR TITLE
Fix AdChoices overlay on about native ad

### DIFF
--- a/app/src/main/res/layout/ad_about.xml
+++ b/app/src/main/res/layout/ad_about.xml
@@ -37,20 +37,23 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent">
 
-                    <com.google.android.gms.ads.nativead.MediaView
-                        android:id="@+id/ad_media"
+                    <FrameLayout
                         android:layout_width="match_parent"
-                        android:layout_height="match_parent" />
-                </com.google.android.material.card.MaterialCardView>
+                        android:layout_height="match_parent">
 
-                <com.google.android.gms.ads.nativead.AdChoicesView
-                    android:id="@+id/ad_choices"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="4dp"
-                    android:layout_marginEnd="4dp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                        <com.google.android.gms.ads.nativead.MediaView
+                            android:id="@+id/ad_media"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent" />
+
+                        <com.google.android.gms.ads.nativead.AdChoicesView
+                            android:id="@+id/ad_choices"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="top|end"
+                            android:layout_margin="4dp" />
+                    </FrameLayout>
+                </com.google.android.material.card.MaterialCardView>
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/ad_headline"


### PR DESCRIPTION
## Summary
- wrap the about screen native ad media content in a container that overlays the AdChoices view
- ensure the "Why this ad" affordance renders on top of the media card instead of being obscured

## Testing
- ./gradlew test *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdcf0e1850832daa8ac70e931798bd