### PR TITLE
Improve bottom banner ad layering and loading state

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainActivity.java
@@ -47,7 +47,9 @@ import com.d4rk.androidtutorials.java.ui.screens.support.SupportActivity;
 import com.d4rk.androidtutorials.java.utils.ConsentUtils;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 import com.d4rk.androidtutorials.java.utils.ReviewHelper;
+import com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView;
 import com.google.android.material.navigation.NavigationBarView;
+import com.google.android.material.progressindicator.CircularProgressIndicator;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.android.play.core.appupdate.AppUpdateInfo;
 import com.google.android.play.core.appupdate.AppUpdateManager;
@@ -75,18 +77,7 @@ public class MainActivity extends AppCompatActivity {
         @Override
         public void onResume(@NonNull LifecycleOwner owner) {
             ConsentUtils.applyStoredConsent(MainActivity.this);
-            ActivityMainBinding binding = mBinding;
-            if (binding != null) {
-                View adView = binding.adView;
-                if (adView != null) {
-                    View adPlaceholder = binding.adPlaceholder;
-                    if (adPlaceholder != null) {
-                        adPlaceholder.setVisibility(View.GONE);
-                    }
-                    adView.setVisibility(View.VISIBLE);
-                    AdUtils.loadBanner(adView);
-                }
-            }
+            updateBottomBannerVisibility(!shouldUseNavigationRail());
         }
     };
     private MainViewModel mainViewModel;
@@ -97,6 +88,7 @@ public class MainActivity extends AppCompatActivity {
     private AppUpdateManager appUpdateManager;
     private InstallStateUpdatedListener installStateUpdatedListener;
     private long backPressedTime;
+    private boolean bottomBannerLoading;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -217,24 +209,17 @@ public class MainActivity extends AppCompatActivity {
                     navRail.setVisibility(View.VISIBLE);
                 }
                 navBarView.setVisibility(View.GONE);
+                updateBottomBannerVisibility(false);
                 WindowCompat.enableEdgeToEdge(this.getWindow());
             } else {
                 if (navRail != null) {
                     navRail.setVisibility(View.GONE);
                 }
                 navBarView.setVisibility(View.VISIBLE);
+                updateBottomBannerVisibility(true);
                 EdgeToEdgeDelegate.applyBottomBar(this, binding.container, navBarView);
 
                 navBarView.setLabelVisibilityMode(uiState.bottomNavVisibility());
-                View adView = binding.adView;
-                if (adView != null) {
-                    View adPlaceholder = binding.adPlaceholder;
-                    if (adPlaceholder != null) {
-                        adPlaceholder.setVisibility(View.GONE);
-                    }
-                    adView.setVisibility(View.VISIBLE);
-                    AdUtils.loadBanner(adView);
-                }
             }
 
             NavHostFragment navHostFragment = (NavHostFragment)
@@ -326,10 +311,65 @@ public class MainActivity extends AppCompatActivity {
         mainViewModel.getLoadingState().observe(this, isLoading -> {
             ActivityMainBinding binding = mBinding;
             if (binding != null) {
-                assert binding.progressBar != null;
-                binding.progressBar.setVisibility(Boolean.TRUE.equals(isLoading) ? View.VISIBLE : View.GONE);
+                CircularProgressIndicator progressIndicator = binding.progressBar;
+                if (progressIndicator != null) {
+                    if (Boolean.TRUE.equals(isLoading)) {
+                        progressIndicator.show();
+                    } else {
+                        progressIndicator.hide();
+                    }
+                }
             }
         });
+    }
+
+    private void updateBottomBannerVisibility(boolean showBanner) {
+        ActivityMainBinding binding = mBinding;
+        if (binding == null) {
+            return;
+        }
+        View adContainer = binding.adContainer;
+        if (adContainer != null) {
+            adContainer.setVisibility(showBanner ? View.VISIBLE : View.GONE);
+        }
+        NativeAdBannerView adView = binding.adView;
+        View adPlaceholder = binding.adPlaceholder;
+        if (adView == null) {
+            if (adPlaceholder != null) {
+                adPlaceholder.setVisibility(View.GONE);
+            }
+            return;
+        }
+        if (!showBanner) {
+            if (adPlaceholder != null) {
+                adPlaceholder.setVisibility(View.GONE);
+            }
+            adView.setVisibility(View.GONE);
+            adView.removeAllViews();
+            bottomBannerLoading = false;
+            return;
+        }
+
+        if (adPlaceholder != null) {
+            adPlaceholder.setVisibility(View.VISIBLE);
+        }
+        if (adView.getVisibility() != View.VISIBLE || adView.getChildCount() > 0) {
+            bottomBannerLoading = false;
+        }
+
+        adView.setVisibility(View.VISIBLE);
+        if (adView.getChildCount() > 0) {
+            if (adPlaceholder != null) {
+                adPlaceholder.setVisibility(View.GONE);
+            }
+            bottomBannerLoading = false;
+            return;
+        }
+
+        if (!bottomBannerLoading) {
+            bottomBannerLoading = true;
+            AdUtils.loadBanner(adView);
+        }
     }
 
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -41,27 +41,6 @@
         app:layout_constraintTop_toBottomOf="@id/app_bar_layout"
         app:navGraph="@navigation/mobile_navigation" />
 
-    <FrameLayout
-        android:id="@+id/ad_container"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintBottom_toTopOf="@+id/nav_view"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
-
-        <View
-            android:id="@+id/ad_placeholder"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="?attr/colorSurfaceContainer" />
-
-        <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
-            android:id="@+id/ad_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:nativeAdLayout="@layout/ad_bottom_app_bar" />
-    </FrameLayout>
-
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/nav_view"
         android:layout_width="match_parent"
@@ -70,10 +49,40 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:menu="@menu/bottom_nav_menu" />
 
-    <ProgressBar
+    <FrameLayout
+        android:id="@+id/ad_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:clipChildren="false"
+        android:clipToPadding="false"
+        android:elevation="8dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@+id/nav_view"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <View
+            android:id="@+id/ad_placeholder"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="?attr/colorSurfaceContainer"
+            android:visibility="gone" />
+
+        <com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView
+            android:id="@+id/ad_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:nativeAdLayout="@layout/ad_bottom_app_bar" />
+    </FrameLayout>
+
+    <com.google.android.material.progressindicator.CircularProgressIndicator
         android:id="@+id/progress_bar"
+        style="@style/Widget.Material3.CircularProgressIndicator"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/ad_bottom_app_bar.xml
+++ b/app/src/main/res/layout/ad_bottom_app_bar.xml
@@ -1,63 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.gms.ads.nativead.NativeAdView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <androidx.appcompat.widget.LinearLayoutCompat
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/ad_card"
+        style="@style/Widget.Material3.CardView.Elevated"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:background="?attr/colorSurfaceContainer"
-        android:padding="12dp">
-
-        <include layout="@layout/ad_attribution" />
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="12dp"
+        app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.CardViewTopRounded">
 
         <androidx.appcompat.widget.LinearLayoutCompat
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:gravity="center_vertical"
-            android:orientation="horizontal">
+            android:orientation="vertical"
+            android:paddingHorizontal="16dp"
+            android:paddingTop="12dp"
+            android:paddingBottom="12dp">
 
-            <androidx.appcompat.widget.AppCompatImageView
-                android:id="@+id/ad_app_icon"
-                android:layout_width="48dp"
-                android:layout_height="48dp"
-                android:layout_marginEnd="12dp"
-                android:visibility="gone" />
+            <include layout="@layout/ad_attribution" />
 
             <androidx.appcompat.widget.LinearLayoutCompat
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:orientation="vertical">
+                android:layout_marginTop="8dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/ad_headline"
+                <androidx.appcompat.widget.AppCompatImageView
+                    android:id="@+id/ad_app_icon"
+                    android:layout_width="40dp"
+                    android:layout_height="40dp"
+                    android:layout_marginEnd="12dp"
+                    android:contentDescription="@null"
+                    android:visibility="gone" />
+
+                <androidx.appcompat.widget.LinearLayoutCompat
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/ad_headline"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:textAppearance="@style/TextAppearance.Material3.BodyLarge" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/ad_body"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        android:ellipsize="end"
+                        android:maxLines="2"
+                        android:textAppearance="@style/TextAppearance.Material3.BodySmall" />
+                </androidx.appcompat.widget.LinearLayoutCompat>
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/ad_call_to_action"
+                    style="@style/Widget.Material3.Button.TextButton"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:ellipsize="end"
-                    android:maxLines="1"
-                    android:textAppearance="@style/TextAppearance.Material3.BodyMedium" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/ad_body"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:ellipsize="end"
-                    android:maxLines="1"
-                    android:textAppearance="@style/TextAppearance.Material3.BodySmall" />
+                    android:minHeight="40dp"
+                    android:minWidth="88dp" />
             </androidx.appcompat.widget.LinearLayoutCompat>
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/ad_call_to_action"
-                style="@style/Widget.Material3.Button.TextButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:minWidth="88dp"
-                android:minHeight="40dp" />
         </androidx.appcompat.widget.LinearLayoutCompat>
-    </androidx.appcompat.widget.LinearLayoutCompat>
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.gms.ads.nativead.AdChoicesView
+        android:id="@+id/ad_choices"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end|top"
+        android:layout_margin="16dp" />
 </com.google.android.gms.ads.nativead.NativeAdView>
 


### PR DESCRIPTION
## Summary
- ensure the bottom banner ad is only shown for the bottom navigation layout and always sits above the bar
- add a reusable helper to manage banner visibility and prevent duplicate ad load calls while improving the loading indicator handling
- refresh the bottom banner layout to use the shared Material card styling and update the main screen layout for the new progress indicator

## Testing
- `./gradlew test` *(fails: SDK location not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5f2514a8832dbbdd32785459d96e