### PR TITLE
Replace findViewById usages with view binding

### DIFF
--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/NoCodeAdFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/NoCodeAdFragment.java
@@ -47,11 +47,13 @@ public abstract class NoCodeAdFragment<T extends ViewBinding> extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
                              @Nullable Bundle savedInstanceState) {
         binding = inflateBinding(inflater, container);
-        View adView = binding.getRoot().findViewById(R.id.ad_view);
-        AdUtils.loadBanner(adView);
+        AdUtils.loadBanner(getAdView(binding));
         onBindingCreated(binding, savedInstanceState);
         return binding.getRoot();
     }
+
+    @NonNull
+    protected abstract View getAdView(@NonNull T binding);
 
     @Override
     public void onDestroyView() {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/navigation/BaseActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/components/navigation/BaseActivity.java
@@ -3,25 +3,17 @@ package com.d4rk.androidtutorials.java.ui.components.navigation;
 import android.annotation.SuppressLint;
 import android.os.Bundle;
 import android.view.Menu;
-import android.view.View;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.view.menu.MenuBuilder;
 
-import com.d4rk.androidtutorials.java.R;
-import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
-
 public abstract class BaseActivity extends AppCompatActivity {
 
     @Override
     protected void onPostCreate(@Nullable Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
-        View container = findViewById(R.id.container);
-        if (container != null) {
-            EdgeToEdgeDelegate.apply(this, container);
-        }
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
             actionBar.setDisplayHomeAsUpEnabled(true);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/AndroidStudioFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/AndroidStudioFragment.java
@@ -30,14 +30,14 @@ import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.ads.AdUtils;
 import com.d4rk.androidtutorials.java.ads.views.NativeAdBannerView;
 import com.d4rk.androidtutorials.java.databinding.FragmentAndroidStudioBinding;
+import com.d4rk.androidtutorials.java.databinding.ItemPreferenceBinding;
+import com.d4rk.androidtutorials.java.databinding.ItemPreferenceCategoryBinding;
+import com.d4rk.androidtutorials.java.databinding.ItemPreferenceWidgetOpenInNewBinding;
 import com.google.android.gms.ads.AdListener;
 import com.google.android.gms.ads.LoadAdError;
 import com.google.android.material.button.MaterialButton;
-import com.google.android.material.card.MaterialCardView;
-import com.google.android.material.imageview.ShapeableImageView;
 import com.google.android.material.shape.CornerFamily;
 import com.google.android.material.shape.ShapeAppearanceModel;
-import com.google.android.material.textview.MaterialTextView;
 
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
@@ -375,13 +375,19 @@ public class AndroidStudioFragment extends Fragment {
                 adView.setNativeAdUnitId(R.string.native_ad_lessons_list_unit_id);
                 return new AdHolder(adView);
             } else if (viewType == TYPE_CATEGORY) {
-                View view = LayoutInflater.from(parent.getContext())
-                        .inflate(R.layout.item_preference_category, parent, false);
-                return new CategoryHolder(view);
+                ItemPreferenceCategoryBinding binding = ItemPreferenceCategoryBinding.inflate(
+                        LayoutInflater.from(parent.getContext()),
+                        parent,
+                        false
+                );
+                return new CategoryHolder(binding);
             } else {
-                View view = LayoutInflater.from(parent.getContext())
-                        .inflate(R.layout.item_preference, parent, false);
-                return new LessonHolder(view);
+                ItemPreferenceBinding binding = ItemPreferenceBinding.inflate(
+                        LayoutInflater.from(parent.getContext()),
+                        parent,
+                        false
+                );
+                return new LessonHolder(binding);
             }
         }
 
@@ -424,40 +430,36 @@ public class AndroidStudioFragment extends Fragment {
         }
 
         static class LessonHolder extends RecyclerView.ViewHolder {
-            final MaterialCardView card;
-            final ShapeableImageView icon;
-            final MaterialTextView title;
-            final MaterialTextView summary;
-            final FrameLayout widgetFrame;
-            final MaterialButton externalButton;
+            private final ItemPreferenceBinding binding;
+            private final ItemPreferenceWidgetOpenInNewBinding widgetBinding;
 
-            LessonHolder(@NonNull View itemView) {
-                super(itemView);
-                card = (MaterialCardView) itemView;
-                icon = itemView.findViewById(android.R.id.icon);
-                title = itemView.findViewById(android.R.id.title);
-                summary = itemView.findViewById(android.R.id.summary);
-                widgetFrame = itemView.findViewById(android.R.id.widget_frame);
-                LayoutInflater.from(itemView.getContext())
-                        .inflate(R.layout.item_preference_widget_open_in_new, widgetFrame, true);
-                externalButton = widgetFrame.findViewById(R.id.open_in_new);
+            LessonHolder(@NonNull ItemPreferenceBinding binding) {
+                super(binding.getRoot());
+                this.binding = binding;
+                widgetBinding = ItemPreferenceWidgetOpenInNewBinding.inflate(
+                        LayoutInflater.from(binding.getRoot().getContext()),
+                        binding.widgetFrame,
+                        true
+                );
             }
 
             void bind(Lesson lesson, boolean first, boolean last) {
                 if (lesson.iconRes != 0) {
-                    icon.setImageResource(lesson.iconRes);
-                    icon.setVisibility(View.VISIBLE);
+                    binding.icon.setImageResource(lesson.iconRes);
+                    binding.icon.setVisibility(View.VISIBLE);
                 } else {
-                    icon.setVisibility(View.GONE);
+                    binding.icon.setVisibility(View.GONE);
                 }
-                title.setText(lesson.title);
+                binding.title.setText(lesson.title);
                 if (lesson.summary != null) {
-                    summary.setText(lesson.summary);
-                    summary.setVisibility(View.VISIBLE);
+                    binding.summary.setText(lesson.summary);
+                    binding.summary.setVisibility(View.VISIBLE);
                 } else {
-                    summary.setVisibility(View.GONE);
+                    binding.summary.setVisibility(View.GONE);
                 }
                 boolean showExternalButton = lesson.opensInBrowser && lesson.intent != null;
+                FrameLayout widgetFrame = binding.widgetFrame;
+                MaterialButton externalButton = widgetBinding.openInNew;
                 widgetFrame.setVisibility(showExternalButton ? View.VISIBLE : View.GONE);
                 externalButton.setVisibility(showExternalButton ? View.VISIBLE : View.GONE);
                 externalButton.setEnabled(showExternalButton);
@@ -486,30 +488,30 @@ public class AndroidStudioFragment extends Fragment {
                         itemView.getResources().getDisplayMetrics());
                 float dp24 = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 24,
                         itemView.getResources().getDisplayMetrics());
-                ShapeAppearanceModel.Builder builder = card.getShapeAppearanceModel().toBuilder()
+                ShapeAppearanceModel.Builder builder = binding.lessonCard.getShapeAppearanceModel().toBuilder()
                         .setTopLeftCorner(CornerFamily.ROUNDED, first ? dp24 : dp4)
                         .setTopRightCorner(CornerFamily.ROUNDED, first ? dp24 : dp4)
                         .setBottomLeftCorner(CornerFamily.ROUNDED, last ? dp24 : dp4)
                         .setBottomRightCorner(CornerFamily.ROUNDED, last ? dp24 : dp4);
-                card.setShapeAppearanceModel(builder.build());
+                binding.lessonCard.setShapeAppearanceModel(builder.build());
             }
         }
 
         static class CategoryHolder extends RecyclerView.ViewHolder {
-            final MaterialTextView title;
+            private final ItemPreferenceCategoryBinding binding;
 
-            CategoryHolder(@NonNull View itemView) {
-                super(itemView);
-                title = itemView.findViewById(android.R.id.title);
+            CategoryHolder(@NonNull ItemPreferenceCategoryBinding binding) {
+                super(binding.getRoot());
+                this.binding = binding;
             }
 
             void bind(Category category) {
                 if (category.iconRes != 0) {
-                    title.setCompoundDrawablesRelativeWithIntrinsicBounds(category.iconRes, 0, 0, 0);
+                    binding.title.setCompoundDrawablesRelativeWithIntrinsicBounds(category.iconRes, 0, 0, 0);
                 } else {
-                    title.setCompoundDrawablesRelativeWithIntrinsicBounds(0, 0, 0, 0);
+                    binding.title.setCompoundDrawablesRelativeWithIntrinsicBounds(0, 0, 0, 0);
                 }
-                title.setText(category.title);
+                binding.title.setText(category.title);
             }
         }
     }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/sdk/AndroidSDK.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/sdk/AndroidSDK.java
@@ -64,7 +64,8 @@ public class AndroidSDK extends UpNavigationActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         binding = ActivityAndroidSdkBinding.inflate(getLayoutInflater());
-        setContentView(binding.getRoot());        EdgeToEdgeDelegate.apply(this, binding.scrollView);
+        setContentView(binding.getRoot());
+        EdgeToEdgeDelegate.apply(this, binding.scrollView);
 
         AdUtils.loadBanner(binding.adViewBottom);
         AdUtils.loadBanner(binding.adView);
@@ -74,7 +75,7 @@ public class AndroidSDK extends UpNavigationActivity {
     }
 
     private void createDynamicTable() {
-        TableLayout tableLayout = binding.cardViewTableLayout.findViewById(R.id.table_layout);
+        TableLayout tableLayout = binding.tableLayout;
         for (AndroidVersion version : androidVersions) {
             TableRow row = new TableRow(this);
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/NavigationAndSearchingShortcutsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/basics/shortcuts/tabs/NavigationAndSearchingShortcutsActivity.java
@@ -2,17 +2,15 @@ package com.d4rk.androidtutorials.java.ui.screens.android.lessons.basics.shortcu
 
 import android.os.Bundle;
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
-import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.ads.AdUtils;
 import com.d4rk.androidtutorials.java.databinding.ActivityShortcutsNavigationAndSearchingBinding;
+import com.d4rk.androidtutorials.java.databinding.ItemShortcutBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 
@@ -72,15 +70,14 @@ public class NavigationAndSearchingShortcutsActivity extends UpNavigationActivit
         @NonNull
         @Override
         public ShortcutHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-            View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_shortcut, parent, false);
-            return new ShortcutHolder(view);
+            ItemShortcutBinding binding = ItemShortcutBinding.inflate(LayoutInflater.from(parent.getContext()), parent, false);
+            return new ShortcutHolder(binding);
         }
 
         @Override
         public void onBindViewHolder(@NonNull ShortcutHolder holder, int position) {
             Shortcut item = items.get(position);
-            holder.key.setText(item.key);
-            holder.description.setText(item.description);
+            holder.bind(item);
         }
 
         @Override
@@ -89,13 +86,16 @@ public class NavigationAndSearchingShortcutsActivity extends UpNavigationActivit
         }
 
         static class ShortcutHolder extends RecyclerView.ViewHolder {
-            final TextView key;
-            final TextView description;
+            private final ItemShortcutBinding binding;
 
-            ShortcutHolder(@NonNull View itemView) {
-                super(itemView);
-                key = itemView.findViewById(R.id.shortcut_key);
-                description = itemView.findViewById(R.id.shortcut_description);
+            ShortcutHolder(@NonNull ItemShortcutBinding binding) {
+                super(binding.getRoot());
+                this.binding = binding;
+            }
+
+            void bind(@NonNull Shortcut shortcut) {
+                binding.shortcutKey.setText(shortcut.key());
+                binding.shortcutDescription.setText(shortcut.description());
             }
         }
     }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/tabs/ButtonsTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/buttons/tabs/ButtonsTabCodeFragment.java
@@ -5,6 +5,7 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
@@ -30,6 +31,12 @@ public class ButtonsTabCodeFragment extends NoCodeAdFragment<FragmentSameCodeBin
     @NonNull
     protected FragmentSameCodeBinding inflateBinding(@NonNull LayoutInflater inflater, ViewGroup container) {
         return FragmentSameCodeBinding.inflate(inflater, container, false);
+    }
+
+    @Override
+    @NonNull
+    protected View getAdView(@NonNull FragmentSameCodeBinding binding) {
+        return binding.adView;
     }
 
     @Override

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/radio/RadioButtonsActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/buttons/radio/RadioButtonsActivity.java
@@ -4,13 +4,14 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.widget.RadioButton;
+import android.util.SparseArray;
 
 import com.d4rk.androidtutorials.java.databinding.ActivityRadioButtonsBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import com.d4rk.androidtutorials.java.ui.screens.android.CodeActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 import com.google.android.material.snackbar.Snackbar;
+import com.google.android.material.radiobutton.MaterialRadioButton;
 
 public class RadioButtonsActivity extends UpNavigationActivity {
     private final Handler handler = new Handler(Looper.getMainLooper());
@@ -24,9 +25,15 @@ public class RadioButtonsActivity extends UpNavigationActivity {
 
         EdgeToEdgeDelegate.apply(this, binding.container);
 
+        SparseArray<MaterialRadioButton> radioButtons = new SparseArray<>();
+        radioButtons.put(binding.radioButtonFirstOption.getId(), binding.radioButtonFirstOption);
+        radioButtons.put(binding.radioButtonSecondOption.getId(), binding.radioButtonSecondOption);
+
         binding.radioGroup.setOnCheckedChangeListener((group, checkedId) -> {
-            RadioButton radioButton = findViewById(checkedId);
-            Snackbar.make(binding.getRoot(), radioButton.getText(), Snackbar.LENGTH_SHORT).show();
+            MaterialRadioButton radioButton = radioButtons.get(checkedId);
+            if (radioButton != null) {
+                Snackbar.make(binding.getRoot(), radioButton.getText(), Snackbar.LENGTH_SHORT).show();
+            }
         });
 
         binding.floatingButtonShowSyntax.setOnClickListener(v -> {

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/clock/tabs/ClockTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/clocks/clock/tabs/ClockTabCodeFragment.java
@@ -1,6 +1,7 @@
 package com.d4rk.androidtutorials.java.ui.screens.android.lessons.clocks.clock.tabs;
 
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
@@ -13,5 +14,11 @@ public class ClockTabCodeFragment extends NoCodeAdFragment<FragmentNoCodeBinding
     @NonNull
     protected FragmentNoCodeBinding inflateBinding(@NonNull LayoutInflater inflater, ViewGroup container) {
         return FragmentNoCodeBinding.inflate(inflater, container, false);
+    }
+
+    @Override
+    @NonNull
+    protected View getAdView(@NonNull FragmentNoCodeBinding binding) {
+        return binding.adView;
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/data/room/RoomActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/data/room/RoomActivity.java
@@ -5,7 +5,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
@@ -14,11 +13,10 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.ListAdapter;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.databinding.ActivityRoomBinding;
+import com.d4rk.androidtutorials.java.databinding.ItemNoteBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
-import com.google.android.material.textview.MaterialTextView;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -107,22 +105,29 @@ public class RoomActivity extends UpNavigationActivity {
         @NonNull
         @Override
         public NoteViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-            View view = LayoutInflater.from(parent.getContext())
-                    .inflate(R.layout.item_note, parent, false);
-            return new NoteViewHolder(view);
+            ItemNoteBinding binding = ItemNoteBinding.inflate(
+                    LayoutInflater.from(parent.getContext()),
+                    parent,
+                    false
+            );
+            return new NoteViewHolder(binding);
         }
 
         @Override
         public void onBindViewHolder(@NonNull NoteViewHolder holder, int position) {
-            holder.textView.setText(getItem(position).getText());
+            holder.bind(getItem(position));
         }
 
         static class NoteViewHolder extends RecyclerView.ViewHolder {
-            final MaterialTextView textView;
+            private final ItemNoteBinding binding;
 
-            NoteViewHolder(View itemView) {
-                super(itemView);
-                textView = itemView.findViewById(R.id.textViewNote);
+            NoteViewHolder(@NonNull ItemNoteBinding binding) {
+                super(binding.getRoot());
+                this.binding = binding;
+            }
+
+            void bind(@NonNull Note note) {
+                binding.textViewNote.setText(note.getText());
             }
         }
     }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/data/room/tabs/RoomTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/data/room/tabs/RoomTabCodeFragment.java
@@ -5,6 +5,7 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
@@ -33,6 +34,12 @@ public class RoomTabCodeFragment extends NoCodeAdFragment<FragmentCodeBinding> {
     @NonNull
     protected FragmentCodeBinding inflateBinding(@NonNull LayoutInflater inflater, ViewGroup container) {
         return FragmentCodeBinding.inflate(inflater, container, false);
+    }
+
+    @Override
+    @NonNull
+    protected View getAdView(@NonNull FragmentCodeBinding binding) {
+        return binding.adView;
     }
 
     @Override

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/linear/tabs/LinearLayoutTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/linear/tabs/LinearLayoutTabCodeFragment.java
@@ -1,6 +1,7 @@
 package com.d4rk.androidtutorials.java.ui.screens.android.lessons.layouts.linear.tabs;
 
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
@@ -13,5 +14,11 @@ public class LinearLayoutTabCodeFragment extends NoCodeAdFragment<FragmentNoCode
     @NonNull
     protected FragmentNoCodeBinding inflateBinding(@NonNull LayoutInflater inflater, ViewGroup container) {
         return FragmentNoCodeBinding.inflate(inflater, container, false);
+    }
+
+    @Override
+    @NonNull
+    protected View getAdView(@NonNull FragmentNoCodeBinding binding) {
+        return binding.adView;
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/relative/tabs/RelativeLayoutTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/relative/tabs/RelativeLayoutTabCodeFragment.java
@@ -1,6 +1,7 @@
 package com.d4rk.androidtutorials.java.ui.screens.android.lessons.layouts.relative.tabs;
 
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
@@ -13,5 +14,11 @@ public class RelativeLayoutTabCodeFragment extends NoCodeAdFragment<FragmentNoCo
     @NonNull
     protected FragmentNoCodeBinding inflateBinding(@NonNull LayoutInflater inflater, ViewGroup container) {
         return FragmentNoCodeBinding.inflate(inflater, container, false);
+    }
+
+    @Override
+    @NonNull
+    protected View getAdView(@NonNull FragmentNoCodeBinding binding) {
+        return binding.adView;
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/table/tabs/TableLayoutTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/layouts/table/tabs/TableLayoutTabCodeFragment.java
@@ -1,6 +1,7 @@
 package com.d4rk.androidtutorials.java.ui.screens.android.lessons.layouts.table.tabs;
 
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
@@ -13,5 +14,11 @@ public class TableLayoutTabCodeFragment extends NoCodeAdFragment<FragmentNoCodeB
     @NonNull
     protected FragmentNoCodeBinding inflateBinding(@NonNull LayoutInflater inflater, ViewGroup container) {
         return FragmentNoCodeBinding.inflate(inflater, container, false);
+    }
+
+    @Override
+    @NonNull
+    protected View getAdView(@NonNull FragmentNoCodeBinding binding) {
+        return binding.adView;
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/networking/retrofit/tabs/RetrofitTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/networking/retrofit/tabs/RetrofitTabCodeFragment.java
@@ -5,6 +5,7 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
@@ -33,6 +34,12 @@ public class RetrofitTabCodeFragment extends NoCodeAdFragment<FragmentCodeBindin
     @NonNull
     protected FragmentCodeBinding inflateBinding(@NonNull LayoutInflater inflater, ViewGroup container) {
         return FragmentCodeBinding.inflate(inflater, container, false);
+    }
+
+    @Override
+    @NonNull
+    protected View getAdView(@NonNull FragmentCodeBinding binding) {
+        return binding.adView;
     }
 
     @Override

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/progress/progressbar/tabs/ProgressBarTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/progress/progressbar/tabs/ProgressBarTabCodeFragment.java
@@ -5,6 +5,7 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
@@ -30,6 +31,12 @@ public class ProgressBarTabCodeFragment extends NoCodeAdFragment<FragmentCodeBin
     @NonNull
     protected FragmentCodeBinding inflateBinding(@NonNull LayoutInflater inflater, ViewGroup container) {
         return FragmentCodeBinding.inflate(inflater, container, false);
+    }
+
+    @Override
+    @NonNull
+    protected View getAdView(@NonNull FragmentCodeBinding binding) {
+        return binding.adView;
     }
 
     @Override

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/grid/GirdViewActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/grid/GirdViewActivity.java
@@ -1,14 +1,21 @@
 package com.d4rk.androidtutorials.java.ui.screens.android.lessons.views.grid;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
-import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.d4rk.androidtutorials.java.databinding.ActivityGridViewBinding;
+import com.d4rk.androidtutorials.java.databinding.ItemGridLetterBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.UpNavigationActivity;
 import com.d4rk.androidtutorials.java.ui.screens.android.CodeActivity;
 import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
@@ -27,11 +34,11 @@ public class GirdViewActivity extends UpNavigationActivity {
 
         EdgeToEdgeDelegate.apply(this, binding.container);
 
-        ArrayAdapter<String> adapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, numbers);
+        ArrayAdapter<String> adapter = new LettersAdapter(this, numbers);
         binding.gridView.setAdapter(adapter);
         binding.gridView.setOnItemClickListener((adapterView, view, i, l) -> {
-            final TextView textView = view.findViewById(android.R.id.text1);
-            Toast.makeText(this, textView.getText(), Toast.LENGTH_SHORT).show();
+            ItemGridLetterBinding itemBinding = ItemGridLetterBinding.bind(view);
+            Toast.makeText(this, itemBinding.textLetter.getText(), Toast.LENGTH_SHORT).show();
         });
         binding.floatingButtonShowSyntax.setOnClickListener(v -> {
             Intent intent = new Intent(this, CodeActivity.class);
@@ -39,6 +46,32 @@ public class GirdViewActivity extends UpNavigationActivity {
             startActivity(intent);
         });
         handler.postDelayed(() -> binding.floatingButtonShowSyntax.shrink(), 5000);
+    }
+
+
+    private static class LettersAdapter extends ArrayAdapter<String> {
+        private final LayoutInflater inflater;
+
+        LettersAdapter(@NonNull Context context, @NonNull String[] items) {
+            super(context, 0, items);
+            this.inflater = LayoutInflater.from(context);
+        }
+
+        @NonNull
+        @Override
+        public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+            ItemGridLetterBinding itemBinding;
+            if (convertView == null) {
+                itemBinding = ItemGridLetterBinding.inflate(inflater, parent, false);
+                convertView = itemBinding.getRoot();
+                convertView.setTag(itemBinding);
+            } else {
+                itemBinding = (ItemGridLetterBinding) convertView.getTag();
+            }
+            String item = getItem(position);
+            itemBinding.textLetter.setText(item != null ? item : "");
+            return convertView;
+        }
     }
 
 

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/images/tabs/ImagesTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/images/tabs/ImagesTabCodeFragment.java
@@ -1,6 +1,7 @@
 package com.d4rk.androidtutorials.java.ui.screens.android.lessons.views.images.tabs;
 
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
@@ -13,5 +14,11 @@ public class ImagesTabCodeFragment extends NoCodeAdFragment<FragmentNoCodeBindin
     @NonNull
     protected FragmentNoCodeBinding inflateBinding(@NonNull LayoutInflater inflater, ViewGroup container) {
         return FragmentNoCodeBinding.inflate(inflater, container, false);
+    }
+
+    @Override
+    @NonNull
+    protected View getAdView(@NonNull FragmentNoCodeBinding binding) {
+        return binding.adView;
     }
 }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/spinner/tabs/SpinnerTabCodeFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/android/lessons/views/spinner/tabs/SpinnerTabCodeFragment.java
@@ -5,6 +5,7 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
@@ -30,6 +31,12 @@ public class SpinnerTabCodeFragment extends NoCodeAdFragment<FragmentCodeBinding
     @NonNull
     protected FragmentCodeBinding inflateBinding(@NonNull LayoutInflater inflater, ViewGroup container) {
         return FragmentCodeBinding.inflate(inflater, container, false);
+    }
+
+    @Override
+    @NonNull
+    protected View getAdView(@NonNull FragmentCodeBinding binding) {
+        return binding.adView;
     }
 
     @Override

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/help/HelpActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/help/HelpActivity.java
@@ -26,6 +26,7 @@ import com.d4rk.androidtutorials.java.databinding.DialogVersionInfoBinding;
 import com.d4rk.androidtutorials.java.databinding.ItemHelpFaqBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.BaseActivity;
 import com.d4rk.androidtutorials.java.ui.screens.help.repository.HelpRepository;
+import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 import com.d4rk.androidtutorials.java.utils.OpenSourceLicensesUtils;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.android.play.core.review.ReviewInfo;
@@ -59,6 +60,7 @@ public class HelpActivity extends BaseActivity {
         super.onCreate(savedInstanceState);
         binding = ActivityHelpBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+        EdgeToEdgeDelegate.apply(this, binding.container);
         AdUtils.loadBanner(binding.faqNativeAd);
         helpViewModel = new ViewModelProvider(this).get(HelpViewModel.class);
         new FastScrollerBuilder(binding.scrollView)

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/main/MainActivity.java
@@ -379,11 +379,14 @@ public class MainActivity extends AppCompatActivity {
                 })
                 .addOnFailureListener(this, e -> {
                     if (!BuildConfig.DEBUG) {
-                        Snackbar.make(
-                                findViewById(android.R.id.content),
-                                getString(R.string.snack_general_error),
-                                Snackbar.LENGTH_LONG
-                        ).show();
+                        ActivityMainBinding binding = mBinding;
+                        if (binding != null) {
+                            Snackbar.make(
+                                    binding.getRoot(),
+                                    getString(R.string.snack_general_error),
+                                    Snackbar.LENGTH_LONG
+                            ).show();
+                        }
                     }
                 });
     }

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/settings/SettingsFragment.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/settings/SettingsFragment.java
@@ -31,6 +31,7 @@ import androidx.preference.SwitchPreferenceCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.d4rk.androidtutorials.java.R;
+import com.d4rk.androidtutorials.java.databinding.ItemPreferenceBinding;
 import com.d4rk.androidtutorials.java.ui.components.dialogs.RequireRestartDialog;
 import com.d4rk.androidtutorials.java.utils.OpenSourceLicensesUtils;
 import com.google.android.material.card.MaterialCardView;
@@ -318,12 +319,11 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     }
 
     private void syncAccessoryVisibility(@NonNull View itemView) {
-        View icon = itemView.findViewById(android.R.id.icon);
-        boolean showIcon = icon != null && icon.getVisibility() == View.VISIBLE;
-        if (icon != null) {
-            icon.setVisibility(showIcon ? View.VISIBLE : View.GONE);
-        }
-        View widgetFrame = itemView.findViewById(android.R.id.widget_frame);
+        ItemPreferenceBinding binding = ItemPreferenceBinding.bind(itemView);
+        View icon = binding.icon;
+        boolean showIcon = icon.getVisibility() == View.VISIBLE;
+        icon.setVisibility(showIcon ? View.VISIBLE : View.GONE);
+        View widgetFrame = binding.widgetFrame;
         if (widgetFrame instanceof ViewGroup widgetGroup) {
             boolean hasChild = widgetGroup.getChildCount() > 0;
             widgetFrame.setVisibility(hasChild ? View.VISIBLE : View.GONE);

--- a/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/support/SupportActivity.java
+++ b/app/src/main/java/com/d4rk/androidtutorials/java/ui/screens/support/SupportActivity.java
@@ -12,6 +12,7 @@ import com.d4rk.androidtutorials.java.R;
 import com.d4rk.androidtutorials.java.data.repository.SupportRepository;
 import com.d4rk.androidtutorials.java.databinding.ActivitySupportBinding;
 import com.d4rk.androidtutorials.java.ui.components.navigation.BaseActivity;
+import com.d4rk.androidtutorials.java.utils.EdgeToEdgeDelegate;
 import com.google.android.gms.ads.AdRequest;
 
 import java.util.List;
@@ -29,6 +30,8 @@ public class SupportActivity extends BaseActivity {
         super.onCreate(savedInstanceState);
         binding = ActivitySupportBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        EdgeToEdgeDelegate.apply(this, binding.container);
 
         supportViewModel = new ViewModelProvider(this).get(SupportViewModel.class);
 

--- a/app/src/main/res/layout/item_grid_letter.xml
+++ b/app/src/main/res/layout/item_grid_letter.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/Widget.Material3.CardView.Elevated"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    app:cardCornerRadius="16dp"
+    app:contentPadding="16dp">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/text_letter"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:textAppearance="@style/TextAppearance.Material3.TitleLarge"
+        tools:text="A" />
+</com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
## Summary
- replace RecyclerView and preference item lookups with generated view bindings across lessons and settings screens
- update shared NoCodeAdFragment and NativeAdLoader to work with view binding for banner ads
- add a binding-backed GridView adapter and layout while removing BaseActivity's raw view lookups

## Testing
- ./gradlew test *(fails: requires local Android SDK configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a3bcb4ec832dbd3b43d5e2e267e6